### PR TITLE
3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,100 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-05-29
+
+Phase 1 — No-Code Editing Core. pglens moves from "viewer" to "client":
+filter, sort, save views, edit, insert, follow foreign keys, aggregate,
+and export/import — all without typing SQL. Every action has a working
+"Show SQL" disclosure, and no-code UI never sends raw SQL fragments over
+the wire; the server parses structured specs into parameterized queries.
+
+### Added
+
+- **Visual filter builder** above every table grid: column + type-aware
+  operator (`=`, `!=`, ranges, `LIKE`/`ILIKE`, `IN`, `IS NULL`, jsonb
+  `@>`, array `&&`) + value, with a "Show SQL" disclosure of the
+  generated `WHERE`. `GET /api/tables/:tableName` accepts a structured
+  filter spec parsed server-side into parameterized SQL. Cursor
+  pagination falls back to `OFFSET` when a filter is present.
+- **Visual multi-column sort builder**: drag-to-reorder `SortBar` chips
+  (HTML5 DnD, no new deps) plus shift/cmd/ctrl-click multi-sort on
+  grid headers with priority badges. `GET /api/tables/:tableName` gains
+  a structured `sort` array parsed via `buildOrderBy` (identifiers
+  validated against column metadata, direction whitelisted); the primary
+  key is appended as a tie-break. Legacy `sortColumn`/`sortDirection`
+  retained for the v2 client.
+- **Saved views** — named bundles of filter + sort scoped to a
+  `(connection, table)` pair, persisted to `~/.pglens/views.json` with
+  atomic writes and a unique-name guard. `GET/POST/PUT/DELETE
+  /api/views`; listing stays open so the sidebar works with no live
+  pool. `ViewBar` with picker, dirty indicator, save / save-as /
+  rename / delete; the selected view is URL state (`?view=<uuid>`) for
+  deep links, and the sidebar nests views under each table with a count
+  badge.
+- **Type-aware inline editing**: double-click a cell to edit with a
+  per-type widget (boolean toggle, date/datetime picker, JSON/array
+  dialog with validation, UUID text + generate, bigint-safe number,
+  text). `PATCH /api/tables/:tableName/rows` takes `{ where, set }` and
+  emits a parameterized `UPDATE` pinned to the primary key (jsonb
+  stringified + cast). Optimistic update with rollback on error,
+  per-cell spinner, and auto-dismissing error pill. PK columns are not
+  editable.
+- **Schema-generated row insert form** via `POST
+  /api/tables/:tableName/rows` and a parameterized `INSERT` builder
+  (`src/db/insert.js`). Each field is tri-state — DEFAULT (omit) / NULL
+  / value; an empty payload emits `DEFAULT VALUES`. NOT-NULL-without-
+  default columns are required; defaults are ghosted. NOT NULL / CHECK /
+  unique violations surface through the standard error envelope.
+  Includes "Show SQL" and "Insert & add another".
+- **FK click-through navigation**: click any foreign-key cell to slide
+  in a side panel with the full referenced row (fetched through the
+  existing filtered read endpoint — no backend change). Supports chained
+  FK navigation with breadcrumbs, "Show all rows in `<table>` where
+  `<col>` = `<val>`" (jumps to the origin table with the equality filter
+  pre-applied), and "Edit referenced row" inline. URL-carried FK values
+  are type-coerced against column metadata.
+- **Per-column aggregations strip** pinned to the bottom of every grid:
+  count / sum / avg / min / max / stddev / count distinct /
+  count true|false, type-gated and computed server-side against the
+  active filter via `GET /api/tables/:tableName/aggregate`
+  (`src/db/aggregate.js`, reuses `buildWhere`). Sticky `tfoot` fn picker
+  with a Show SQL preview.
+- **Per-table data export** to CSV (RFC 4180), JSON, or SQL `INSERT`
+  via `GET /api/tables/:tableName/export`, respecting the current
+  filter, sort, and a chosen column subset. Rows stream through a
+  server-side cursor with drain-aware backpressure, so memory stays flat
+  regardless of table size. `ExportMenu` dialog with format toggle,
+  per-column picker, and Show SQL.
+- **Per-table CSV import wizard**: upload, map CSV columns → table
+  columns (auto-guessed by header), choose insert mode (`INSERT`,
+  `ON CONFLICT DO NOTHING`, `ON CONFLICT … DO UPDATE`), dry-run preview
+  of rows/conflicts, execute in a transaction.
+
+### Changed
+
+- **Neutral off-black dark mode**: replaced the bluish-slate palette
+  with neutral grays (background ~`#161616`, surfaces lift to `#1c1c1c`,
+  de-tinted borders).
+- **Column metadata** returned by the table read now carries `udtName`,
+  `isNullable`, `hasDefault`, and the raw default expression, so the
+  frontend can pick the right edit/insert widget and ghost defaults.
+- **Global DB dump** (`/api/export`) now reuses the shared `sqlLiteral()`
+  serializer from `src/db/export.js` instead of a hand-coded copy,
+  removing the risk of drift between the global-backup and per-table
+  export paths. Output unchanged.
+
+### Fixed
+
+- **Connection store** now syncs the resolved connection id back after
+  resolution, fixing stale-id state.
+
+### Known limitations
+
+- FK and enum columns in the inline editor and insert form degrade to a
+  text input (with a `→ table.column` hint) until the FK lookup pipeline
+  lands.
+
 ## [3.0.2] - 2026-05-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # pglens
 
-A no-code PostgreSQL workstation. View, explore, visualize, and query your
+A no-code PostgreSQL workstation. View, explore, visualize, edit, and query your
 PostgreSQL databases through a fast local web interface.
 
-> **v3.0.0** is a foundation rewrite. The interface is now a React 18 + TypeScript
+> **v3.1.0** turns pglens from a viewer into a client: filter, sort, save views,
+> inline-edit, insert rows, follow foreign keys, aggregate, and export/import — all
+> without typing SQL. Every no-code action has a "Show SQL" disclosure, and the UI
+> never sends raw SQL fragments; the server parses structured specs into
+> parameterized queries.
+>
+> **v3.0.0** was the foundation rewrite. The interface is a React 18 + TypeScript
 > app, and the server is hardened with per-install auth, OS-keychain secrets, and
 > localhost-only binding. See [Breaking Changes](#breaking-changes-in-v300) before
-> upgrading.
+> upgrading from v2.x.
 
 ## Features
 
@@ -18,7 +24,16 @@ PostgreSQL databases through a fast local web interface.
 - 🗃️ **Schema Selection**: Browse any schema in your database, not just `public`
 - 🕸️ **Schema Visualization**: Interactive auto-laid-out graph (dagre) of table relationships, with filtering, hover spotlight, and minimap
 - 📐 **Schema Export**: Export the diagram as SVG or Mermaid ER (copy or `.mmd` download)
-- 📥 **Import/Export**: Export your database schema as SQL and import it into another connection
+- 🔎 **Visual Filter Builder**: Type-aware operators (`=`, ranges, `LIKE`/`ILIKE`, `IN`, `IS NULL`, jsonb `@>`, array `&&`) above every grid, with Show SQL
+- ↕️ **Visual Multi-Column Sort**: Drag-to-reorder sort chips plus shift/cmd-click header multi-sort with priority badges
+- 💾 **Saved Views**: Named filter + sort bundles per `(connection, table)`, deep-linkable via URL, nested under each table in the sidebar
+- ✏️ **Inline Editing**: Double-click a cell to edit with a per-type widget (boolean, date/datetime, JSON/array, UUID, bigint-safe number); optimistic update with rollback
+- ➕ **Row Insert Form**: Schema-generated form with tri-state DEFAULT / NULL / value fields and "Insert & add another"
+- 🔗 **FK Click-Through**: Click a foreign-key cell to slide in the referenced row, follow chained FKs with breadcrumbs, or jump to all matching rows
+- 🧮 **Per-Column Aggregations**: count / sum / avg / min / max / stddev / count distinct, type-gated and computed server-side against the active filter
+- 📤 **Per-Table Export**: Stream CSV (RFC 4180) / JSON / SQL `INSERT`, respecting the active filter, sort, and chosen columns
+- 📥 **CSV Import Wizard**: Map columns, choose insert mode (`INSERT`, `ON CONFLICT DO NOTHING`/`DO UPDATE`), dry-run preview, transactional execute
+- 📦 **Import/Export Schema**: Export your database schema as SQL and import it into another connection
 - 💽 **Streaming Backup**: Export a database dump with live byte/table progress and cancel
 - ⌨️ **Query Runner**: Advanced-mode raw-SQL escape hatch with a Monaco editor (`Cmd/Ctrl+Enter` to run)
 - 🔎 **Spotlight Search**: Quick table search with `Cmd+K` / `Ctrl+K` for fast navigation

--- a/client-next/src/components/CellEditor.tsx
+++ b/client-next/src/components/CellEditor.tsx
@@ -1,0 +1,535 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Check, Sparkles, X } from "lucide-react";
+
+import type { ColumnMeta } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+/**
+ * Type-aware inline cell editor.
+ *
+ * Two surface modes:
+ *   - **inline** — the editor renders in place of the cell content. Used for
+ *     boolean/number/date/uuid/text/varchar. Commit on Enter or blur, cancel
+ *     on Esc, NULL via the dropdown menu where the type allows it.
+ *   - **dialog** — large or structured values (json/jsonb, arrays) open a
+ *     modal with a textarea + validation. The cell shows a "..." launcher
+ *     while the dialog is open.
+ *
+ * Foreign-key and enum columns fall back to a plain text input until their
+ * lookup pipelines land — graceful degradation per roadmap §4.4.
+ */
+
+export type EditorKind =
+  | "boolean"
+  | "date"
+  | "datetime"
+  | "json"
+  | "array"
+  | "number"
+  | "uuid"
+  | "text";
+
+export function detectEditorKind(meta: ColumnMeta): EditorKind {
+  const t = (meta.dataType || "").toLowerCase();
+  const u = (meta.udtName || "").toLowerCase();
+  if (t === "boolean") return "boolean";
+  if (t === "json" || t === "jsonb") return "json";
+  if (t === "array" || u.startsWith("_")) return "array";
+  if (t === "date") return "date";
+  if (t.startsWith("timestamp")) return "datetime";
+  if (t === "uuid") return "uuid";
+  if (
+    t === "integer" ||
+    t === "bigint" ||
+    t === "smallint" ||
+    t === "numeric" ||
+    t === "real" ||
+    t === "double precision" ||
+    t.startsWith("decimal")
+  ) {
+    return "number";
+  }
+  return "text";
+}
+
+/** Format a row value into the string the inline editor starts with. */
+function toEditableString(value: unknown, kind: EditorKind): string {
+  if (value === null || value === undefined) return "";
+  if (kind === "datetime") {
+    // <input type="datetime-local"> wants `YYYY-MM-DDTHH:MM[:SS]` with no
+    // trailing Z. Drop the timezone — the backend stores the user's intended
+    // wall-clock value and Postgres re-applies session timezone.
+    const d = value instanceof Date ? value : new Date(String(value));
+    if (Number.isNaN(d.getTime())) return String(value);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return (
+      `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+      `T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+    );
+  }
+  if (kind === "date") {
+    const d = value instanceof Date ? value : new Date(String(value));
+    if (Number.isNaN(d.getTime())) return String(value);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  }
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+interface CellEditorProps {
+  meta: ColumnMeta;
+  value: unknown;
+  onCommit: (next: unknown) => void;
+  onCancel: () => void;
+}
+
+export function CellEditor(props: CellEditorProps) {
+  const kind = useMemo(() => detectEditorKind(props.meta), [props.meta]);
+  switch (kind) {
+    case "boolean":
+      return <BooleanEditor {...props} />;
+    case "json":
+      return <JsonArrayDialog {...props} kind="json" />;
+    case "array":
+      return <JsonArrayDialog {...props} kind="array" />;
+    case "uuid":
+      return <UuidEditor {...props} />;
+    case "number":
+      return <NumberEditor {...props} />;
+    case "date":
+      return <DateEditor {...props} mode="date" />;
+    case "datetime":
+      return <DateEditor {...props} mode="datetime" />;
+    case "text":
+    default:
+      return <TextEditor {...props} />;
+  }
+}
+
+// ---- Common building blocks -----------------------------------------------
+
+interface InlineWrapperProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+function InlineWrapper({ children, className }: InlineWrapperProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 rounded-sm bg-background ring-2 ring-primary",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+const baseInputCls =
+  "h-7 min-w-0 flex-1 rounded-sm border-none bg-transparent px-1 text-xs font-mono outline-none";
+
+// ---- Inline editors --------------------------------------------------------
+
+function TextEditor({ meta, value, onCommit, onCancel }: CellEditorProps) {
+  const ref = useRef<HTMLInputElement>(null);
+  const [text, setText] = useState(() => toEditableString(value, "text"));
+
+  useLayoutEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+
+  function commit() {
+    // Preserve the original NULL when the user opens the editor on a NULL
+    // cell and presses Enter without typing — otherwise empty string is the
+    // user's actual choice and we send it.
+    if (value === null && text === "") {
+      onCancel();
+      return;
+    }
+    onCommit(text);
+  }
+
+  return (
+    <InlineWrapper>
+      <input
+        ref={ref}
+        className={baseInputCls}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          else if (e.key === "Escape") onCancel();
+        }}
+      />
+      {meta.isNullable && <NullAction onClick={() => onCommit(null)} />}
+    </InlineWrapper>
+  );
+}
+
+function NumberEditor({ meta, value, onCommit, onCancel }: CellEditorProps) {
+  const ref = useRef<HTMLInputElement>(null);
+  const [text, setText] = useState(() => toEditableString(value, "number"));
+  const [error, setError] = useState<string | null>(null);
+
+  useLayoutEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+
+  function commit() {
+    if (text === "") {
+      if (value === null) return onCancel();
+      if (meta.isNullable) return onCommit(null);
+      setError("Required");
+      return;
+    }
+    // Send the trimmed string so bigint precision is preserved across the
+    // wire; the server's `postgres` driver parses the literal directly.
+    const trimmed = text.trim();
+    if (!/^-?\d+(\.\d+)?([eE][-+]?\d+)?$/.test(trimmed)) {
+      setError("Not a number");
+      return;
+    }
+    onCommit(trimmed);
+  }
+
+  return (
+    <InlineWrapper className={error ? "ring-destructive" : undefined}>
+      <input
+        ref={ref}
+        inputMode="decimal"
+        className={baseInputCls}
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value);
+          if (error) setError(null);
+        }}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          else if (e.key === "Escape") onCancel();
+        }}
+      />
+      {meta.isNullable && <NullAction onClick={() => onCommit(null)} />}
+    </InlineWrapper>
+  );
+}
+
+function DateEditor({
+  meta,
+  value,
+  onCommit,
+  onCancel,
+  mode,
+}: CellEditorProps & { mode: "date" | "datetime" }) {
+  const ref = useRef<HTMLInputElement>(null);
+  const [text, setText] = useState(() =>
+    toEditableString(value, mode === "date" ? "date" : "datetime"),
+  );
+
+  useLayoutEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  function commit() {
+    if (text === "") {
+      if (value === null) return onCancel();
+      if (meta.isNullable) return onCommit(null);
+      return onCancel();
+    }
+    onCommit(text);
+  }
+
+  return (
+    <InlineWrapper>
+      <input
+        ref={ref}
+        type={mode === "date" ? "date" : "datetime-local"}
+        step={mode === "datetime" ? 1 : undefined}
+        className={baseInputCls}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          else if (e.key === "Escape") onCancel();
+        }}
+      />
+      {meta.isNullable && <NullAction onClick={() => onCommit(null)} />}
+    </InlineWrapper>
+  );
+}
+
+function BooleanEditor({ meta, value, onCommit, onCancel }: CellEditorProps) {
+  const ref = useRef<HTMLSelectElement>(null);
+  // Use the raw value as the select state so the user's NULL choice maps to
+  // a distinct option separate from "false".
+  const initial =
+    value === null || value === undefined ? "null" : value ? "true" : "false";
+  const [choice, setChoice] = useState<"true" | "false" | "null">(
+    initial as "true" | "false" | "null",
+  );
+
+  useLayoutEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  function commit(next: "true" | "false" | "null" = choice) {
+    if (next === "null") return onCommit(null);
+    onCommit(next === "true");
+  }
+
+  return (
+    <InlineWrapper>
+      <select
+        ref={ref}
+        className="h-7 flex-1 bg-transparent px-1 text-xs outline-none"
+        value={choice}
+        onChange={(e) => {
+          const v = e.target.value as "true" | "false" | "null";
+          setChoice(v);
+          commit(v);
+        }}
+        onBlur={() => commit()}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onCancel();
+          if (e.key === "Enter") commit();
+        }}
+      >
+        <option value="true">true</option>
+        <option value="false">false</option>
+        {meta.isNullable && <option value="null">NULL</option>}
+      </select>
+    </InlineWrapper>
+  );
+}
+
+function UuidEditor({ meta, value, onCommit, onCancel }: CellEditorProps) {
+  const ref = useRef<HTMLInputElement>(null);
+  const [text, setText] = useState(() => toEditableString(value, "uuid"));
+  const [error, setError] = useState<string | null>(null);
+
+  useLayoutEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+
+  function commit() {
+    if (text === "") {
+      if (value === null) return onCancel();
+      if (meta.isNullable) return onCommit(null);
+      setError("Required");
+      return;
+    }
+    if (!UUID_RE.test(text)) {
+      setError("Not a UUID");
+      return;
+    }
+    onCommit(text);
+  }
+
+  function generate() {
+    const uuid =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : fallbackUuid();
+    setText(uuid);
+    setError(null);
+    // Focus stays on the field so the user can review or press Enter to
+    // commit; this matches the existing UX patterns of "generate and review."
+    requestAnimationFrame(() => ref.current?.select());
+  }
+
+  return (
+    <InlineWrapper className={error ? "ring-destructive" : undefined}>
+      <input
+        ref={ref}
+        className={baseInputCls}
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value);
+          if (error) setError(null);
+        }}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          else if (e.key === "Escape") onCancel();
+        }}
+        placeholder="00000000-0000-0000-0000-000000000000"
+      />
+      <button
+        type="button"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={generate}
+        title="Generate UUID v4"
+        className="rounded-sm p-1 text-muted-foreground hover:text-foreground"
+      >
+        <Sparkles className="h-3 w-3" />
+      </button>
+      {meta.isNullable && <NullAction onClick={() => onCommit(null)} />}
+    </InlineWrapper>
+  );
+}
+
+function fallbackUuid(): string {
+  // Sufficient for offline / unsupported environments.
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const h = Array.from(bytes, (b) => b.toString(16).padStart(2, "0"));
+  return `${h.slice(0, 4).join("")}-${h.slice(4, 6).join("")}-${h.slice(6, 8).join("")}-${h.slice(8, 10).join("")}-${h.slice(10, 16).join("")}`;
+}
+
+// ---- Dialog editor (json / array) -----------------------------------------
+
+function JsonArrayDialog({
+  meta,
+  value,
+  onCommit,
+  onCancel,
+  kind,
+}: CellEditorProps & { kind: "json" | "array" }) {
+  // The dialog mounts open immediately so opening the cell editor and the
+  // popup feels like one motion. Closing the dialog cancels the edit unless
+  // the user clicked the explicit Save button.
+  const [text, setText] = useState(() =>
+    value === null ? "" : toEditableString(value, "json"),
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const save = useCallback(() => {
+    if (text === "" && meta.isNullable) {
+      onCommit(null);
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      setError(`Invalid JSON: ${(err as Error).message}`);
+      return;
+    }
+    if (kind === "array" && !Array.isArray(parsed)) {
+      setError("Array column requires a JSON array (e.g. [\"a\", \"b\"]).");
+      return;
+    }
+    onCommit(parsed);
+  }, [text, meta.isNullable, onCommit, kind]);
+
+  // Cmd/Ctrl-Enter to save without taking focus off the textarea — matches
+  // the QueryRunner editor convention.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        save();
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [save]);
+
+  return (
+    <Dialog
+      open
+      onClose={onCancel}
+      title={`Edit ${kind === "json" ? "JSON" : "array"} value`}
+      className="max-w-3xl"
+      footer={
+        <>
+          {meta.isNullable && text !== "" && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setText("");
+                setError(null);
+              }}
+            >
+              Clear
+            </Button>
+          )}
+          <Button variant="outline" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={save}>
+            <Check className="h-3 w-3" />
+            Save
+          </Button>
+        </>
+      }
+    >
+      <textarea
+        autoFocus
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value);
+          if (error) setError(null);
+        }}
+        spellCheck={false}
+        className="min-h-[280px] w-full resize-y rounded-md border border-input bg-background p-3 font-mono text-xs"
+        placeholder={
+          kind === "json" ? '{ "key": "value" }' : '["item1", "item2"]'
+        }
+      />
+      <p className="mt-2 text-xs text-muted-foreground">
+        {meta.isNullable
+          ? "Empty value saves as SQL NULL. Cmd/Ctrl + Enter to save."
+          : "Cmd/Ctrl + Enter to save."}
+      </p>
+      {error && (
+        <div className="mt-2 rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+    </Dialog>
+  );
+}
+
+// ---- Small affordances ----------------------------------------------------
+
+function NullAction({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      // mousedown.preventDefault keeps the input's blur from firing first,
+      // which would commit the current text before the NULL click lands.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className="mr-1 rounded-sm px-1 text-[10px] text-muted-foreground hover:bg-accent hover:text-foreground"
+      title="Set to NULL"
+    >
+      ∅
+    </button>
+  );
+}
+
+export function CancelHint() {
+  return (
+    <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
+      <X className="h-2.5 w-2.5" /> Esc
+    </span>
+  );
+}

--- a/client-next/src/components/DataGrid.tsx
+++ b/client-next/src/components/DataGrid.tsx
@@ -49,6 +49,12 @@ interface DataGridProps {
    */
   editable?: boolean;
   onCommitCell?: CommitCell;
+  /**
+   * Click handler for a foreign-key cell. Fired on a single click of a non-
+   * null FK value — the parent opens the referenced-row side panel. Omit to
+   * render FK cells as plain values (graceful degradation).
+   */
+  onOpenFk?: (column: string, value: unknown) => void;
 }
 
 /**
@@ -94,11 +100,30 @@ function isJsonCell(value: unknown, dataType?: string): boolean {
 
 function renderCell(
   value: unknown,
-  dataType: string | undefined,
+  meta: ColumnMeta | undefined,
   onOpenJson: (value: unknown) => void,
+  onOpenFk?: (value: unknown) => void,
 ): React.ReactNode {
+  const dataType = meta?.dataType;
   if (value === null || value === undefined) {
     return <span className="italic text-muted-foreground/60">NULL</span>;
+  }
+  // Foreign-key value → click to follow it to the referenced row. Takes
+  // precedence over plain text so the whole value reads as a link, but yields
+  // to JSON (an FK column holding json is not a thing in practice).
+  if (meta?.isForeignKey && meta.foreignKeyRef && onOpenFk) {
+    return (
+      <button
+        onClick={() => onOpenFk(value)}
+        className="flex items-center gap-1 text-violet-600 hover:underline dark:text-violet-400"
+        title={`Follow → ${meta.foreignKeyRef.table}.${meta.foreignKeyRef.column}`}
+      >
+        <LinkIcon className="h-3 w-3 shrink-0" />
+        <span className="truncate">
+          {typeof value === "object" ? JSON.stringify(value) : String(value)}
+        </span>
+      </button>
+    );
   }
   if (isJsonCell(value, dataType)) {
     const data = coerceJson(value);
@@ -133,6 +158,7 @@ export function DataGrid({
   onSortChange,
   editable = false,
   onCommitCell,
+  onOpenFk,
 }: DataGridProps) {
   const columnNames = useMemo(() => Object.keys(columns), [columns]);
   const [jsonCell, setJsonCell] = useState<JsonCell | null>(null);
@@ -156,11 +182,14 @@ export function DataGrid({
         accessorKey: name,
         header: name,
         cell: (info) =>
-          renderCell(info.getValue(), columns[name]?.dataType, (value) =>
-            setJsonCell({ column: name, value }),
+          renderCell(
+            info.getValue(),
+            columns[name],
+            (value) => setJsonCell({ column: name, value }),
+            onOpenFk ? (value) => onOpenFk(name, value) : undefined,
           ),
       })),
-    [columnNames, columns],
+    [columnNames, columns, onOpenFk],
   );
 
   const table = useReactTable({

--- a/client-next/src/components/DataGrid.tsx
+++ b/client-next/src/components/DataGrid.tsx
@@ -1,34 +1,73 @@
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useRef, useState } from "react";
 import {
   flexRender,
   getCoreRowModel,
   useReactTable,
   type ColumnDef,
-} from '@tanstack/react-table'
-import { useVirtualizer } from '@tanstack/react-virtual'
-import { ArrowDown, ArrowUp, Braces, ChevronsUpDown, Key, Link as LinkIcon } from 'lucide-react'
+} from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  ArrowDown,
+  ArrowUp,
+  Braces,
+  ChevronsUpDown,
+  Key,
+  Link as LinkIcon,
+} from "lucide-react";
 
-import { cn } from '@/lib/utils'
-import type { ColumnMeta } from '@/lib/api'
-import { Dialog } from '@/components/ui/dialog'
-import { JsonViewer, coerceJson, isExpandable } from '@/components/JsonViewer'
+import { cn } from "@/lib/utils";
+import type { ColumnMeta, SortEntry } from "@/lib/api";
+import { Dialog } from "@/components/ui/dialog";
+import { JsonViewer, coerceJson, isExpandable } from "@/components/JsonViewer";
 
-export type SortState = { column: string; direction: 'asc' | 'desc' } | null
+export type SortState = SortEntry[];
 
 interface DataGridProps {
-  rows: Array<Record<string, unknown>>
-  columns: Record<string, ColumnMeta>
-  sort: SortState
-  onSortChange: (next: SortState) => void
+  rows: Array<Record<string, unknown>>;
+  columns: Record<string, ColumnMeta>;
+  sort: SortState;
+  onSortChange: (next: SortState) => void;
 }
 
-type JsonCell = { column: string; value: unknown }
+/**
+ * Header click semantics:
+ *   plain click            → make this column the sole sort, cycling its
+ *                            direction asc → desc → unsorted
+ *   shift / cmd / ctrl-click → toggle this column at the end of the priority
+ *                            list, cycling asc → desc → removed
+ *
+ * Mirrors Airtable / TanStack Table conventions so multi-sort feels familiar.
+ */
+function nextSortState(
+  prev: SortState,
+  column: string,
+  additive: boolean,
+): SortState {
+  const idx = prev.findIndex((s) => s.column === column);
+  const current = idx >= 0 ? prev[idx] : null;
+
+  if (!additive) {
+    if (!current) return [{ column, direction: "asc" }];
+    if (current.direction === "asc") return [{ column, direction: "desc" }];
+    return [];
+  }
+
+  if (!current) return [...prev, { column, direction: "asc" }];
+  if (current.direction === "asc") {
+    const next = [...prev];
+    next[idx] = { column, direction: "desc" };
+    return next;
+  }
+  return prev.filter((_, i) => i !== idx);
+}
+
+type JsonCell = { column: string; value: unknown };
 
 /** jsonb/json columns, or any value that parses to an object/array. */
 function isJsonCell(value: unknown, dataType?: string): boolean {
-  const t = dataType?.toLowerCase()
-  if (t === 'jsonb' || t === 'json') return true
-  return isExpandable(coerceJson(value))
+  const t = dataType?.toLowerCase();
+  if (t === "jsonb" || t === "json") return true;
+  return isExpandable(coerceJson(value));
 }
 
 function renderCell(
@@ -37,10 +76,10 @@ function renderCell(
   onOpenJson: (value: unknown) => void,
 ): React.ReactNode {
   if (value === null || value === undefined) {
-    return <span className="italic text-muted-foreground/60">NULL</span>
+    return <span className="italic text-muted-foreground/60">NULL</span>;
   }
   if (isJsonCell(value, dataType)) {
-    const data = coerceJson(value)
+    const data = coerceJson(value);
     return (
       <button
         onClick={() => onOpenJson(data)}
@@ -52,22 +91,22 @@ function renderCell(
           {Array.isArray(data) ? `[${data.length}]` : JSON.stringify(data)}
         </span>
       </button>
-    )
+    );
   }
-  if (typeof value === 'boolean') return value ? 'true' : 'false'
-  if (typeof value === 'number') return String(value)
-  if (typeof value === 'string') return value
-  if (value instanceof Date) return value.toISOString()
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return String(value);
+  if (typeof value === "string") return value;
+  if (value instanceof Date) return value.toISOString();
   try {
-    return JSON.stringify(value)
+    return JSON.stringify(value);
   } catch {
-    return String(value)
+    return String(value);
   }
 }
 
 export function DataGrid({ rows, columns, sort, onSortChange }: DataGridProps) {
-  const columnNames = useMemo(() => Object.keys(columns), [columns])
-  const [jsonCell, setJsonCell] = useState<JsonCell | null>(null)
+  const columnNames = useMemo(() => Object.keys(columns), [columns]);
+  const [jsonCell, setJsonCell] = useState<JsonCell | null>(null);
 
   const colDefs = useMemo<ColumnDef<Record<string, unknown>>[]>(
     () =>
@@ -80,138 +119,151 @@ export function DataGrid({ rows, columns, sort, onSortChange }: DataGridProps) {
           ),
       })),
     [columnNames, columns],
-  )
+  );
 
   const table = useReactTable({
     data: rows,
     columns: colDefs,
     getCoreRowModel: getCoreRowModel(),
-  })
+  });
 
-  const parentRef = useRef<HTMLDivElement>(null)
+  const parentRef = useRef<HTMLDivElement>(null);
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => 32,
     overscan: 12,
-  })
+  });
 
-  const totalSize = rowVirtualizer.getTotalSize()
-  const virtualRows = rowVirtualizer.getVirtualItems()
-  const paddingTop = virtualRows[0]?.start ?? 0
+  const totalSize = rowVirtualizer.getTotalSize();
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const paddingTop = virtualRows[0]?.start ?? 0;
   const paddingBottom =
     virtualRows.length > 0
       ? totalSize - (virtualRows[virtualRows.length - 1]?.end ?? 0)
-      : 0
+      : 0;
 
-  function toggleSort(name: string) {
-    if (sort?.column !== name) onSortChange({ column: name, direction: 'asc' })
-    else if (sort.direction === 'asc')
-      onSortChange({ column: name, direction: 'desc' })
-    else onSortChange(null)
+  function toggleSort(name: string, additive: boolean) {
+    onSortChange(nextSortState(sort, name, additive));
   }
 
   return (
     <>
-    <div
-      ref={parentRef}
-      className="h-full overflow-auto rounded-md border border-border bg-card"
-    >
-      <table className="w-full border-collapse text-sm">
-        <thead className="sticky top-0 z-10 bg-card">
-          {table.getHeaderGroups().map((hg) => (
-            <tr key={hg.id}>
-              {hg.headers.map((header) => {
-                const name = header.column.id
-                const meta = columns[name]
-                const isSorted = sort?.column === name
-                return (
-                  <th
-                    key={header.id}
-                    className="select-none border-b border-border px-2 py-2 text-left align-bottom font-medium text-foreground"
-                  >
-                    <button
-                      onClick={() => toggleSort(name)}
-                      className="group flex w-full items-center gap-1.5 text-left"
+      <div
+        ref={parentRef}
+        className="h-full overflow-auto rounded-md border border-border bg-card"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead className="sticky top-0 z-10 bg-card">
+            {table.getHeaderGroups().map((hg) => (
+              <tr key={hg.id}>
+                {hg.headers.map((header) => {
+                  const name = header.column.id;
+                  const meta = columns[name];
+                  const sortIdx = sort.findIndex((s) => s.column === name);
+                  const sortEntry = sortIdx >= 0 ? sort[sortIdx] : null;
+                  const showPriority = sortEntry && sort.length > 1;
+                  return (
+                    <th
+                      key={header.id}
+                      className="select-none border-b border-border px-2 py-2 text-left align-bottom font-medium text-foreground"
                     >
-                      {meta?.isPrimaryKey && (
-                        <Key className="h-3 w-3 text-amber-500" />
-                      )}
-                      {meta?.isForeignKey && (
-                        <LinkIcon className="h-3 w-3 text-sky-500" />
-                      )}
-                      <span className="truncate">{name}</span>
-                      <span className="ml-auto text-muted-foreground">
-                        {isSorted ? (
-                          sort.direction === 'asc' ? (
-                            <ArrowUp className="h-3 w-3" />
-                          ) : (
-                            <ArrowDown className="h-3 w-3" />
-                          )
-                        ) : (
-                          <ChevronsUpDown className="h-3 w-3 opacity-0 group-hover:opacity-50" />
+                      <button
+                        onClick={(e) =>
+                          toggleSort(name, e.shiftKey || e.metaKey || e.ctrlKey)
+                        }
+                        title="Click to sort. Shift-click to add to multi-sort."
+                        className="group flex w-full items-center gap-1.5 text-left"
+                      >
+                        {meta?.isPrimaryKey && (
+                          <Key className="h-3 w-3 text-amber-500" />
                         )}
-                      </span>
-                    </button>
-                    {meta && (
-                      <div className="mt-0.5 text-[10px] font-normal lowercase text-muted-foreground">
-                        {meta.dataType}
-                      </div>
-                    )}
-                  </th>
-                )
-              })}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {paddingTop > 0 && (
-            <tr>
-              <td style={{ height: paddingTop }} colSpan={columnNames.length} />
-            </tr>
-          )}
-          {virtualRows.map((vr) => {
-            const row = table.getRowModel().rows[vr.index]
-            if (!row) return null
-            return (
-              <tr
-                key={row.id}
-                style={{ height: vr.size }}
-                className={cn(
-                  'border-b border-border/60',
-                  vr.index % 2 === 1 && 'bg-muted/30',
-                )}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <td
-                    key={cell.id}
-                    className="max-w-[420px] truncate px-2 py-1 align-middle font-mono text-xs"
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
+                        {meta?.isForeignKey && (
+                          <LinkIcon className="h-3 w-3 text-sky-500" />
+                        )}
+                        <span className="truncate">{name}</span>
+                        <span className="ml-auto flex items-center gap-1 text-muted-foreground">
+                          {showPriority && (
+                            <span className="rounded bg-primary/15 px-1 text-[10px] font-semibold text-primary">
+                              {sortIdx + 1}
+                            </span>
+                          )}
+                          {sortEntry ? (
+                            sortEntry.direction === "asc" ? (
+                              <ArrowUp className="h-3 w-3" />
+                            ) : (
+                              <ArrowDown className="h-3 w-3" />
+                            )
+                          ) : (
+                            <ChevronsUpDown className="h-3 w-3 opacity-0 group-hover:opacity-50" />
+                          )}
+                        </span>
+                      </button>
+                      {meta && (
+                        <div className="mt-0.5 text-[10px] font-normal lowercase text-muted-foreground">
+                          {meta.dataType}
+                        </div>
+                      )}
+                    </th>
+                  );
+                })}
               </tr>
-            )
-          })}
-          {paddingBottom > 0 && (
-            <tr>
-              <td
-                style={{ height: paddingBottom }}
-                colSpan={columnNames.length}
-              />
-            </tr>
-          )}
-        </tbody>
-      </table>
-    </div>
-    <Dialog
-      open={jsonCell !== null}
-      onClose={() => setJsonCell(null)}
-      title={jsonCell?.column ?? 'JSON'}
-      className="max-w-2xl"
-    >
-      {jsonCell && <JsonViewer value={jsonCell.value} />}
-    </Dialog>
+            ))}
+          </thead>
+          <tbody>
+            {paddingTop > 0 && (
+              <tr>
+                <td
+                  style={{ height: paddingTop }}
+                  colSpan={columnNames.length}
+                />
+              </tr>
+            )}
+            {virtualRows.map((vr) => {
+              const row = table.getRowModel().rows[vr.index];
+              if (!row) return null;
+              return (
+                <tr
+                  key={row.id}
+                  style={{ height: vr.size }}
+                  className={cn(
+                    "border-b border-border/60",
+                    vr.index % 2 === 1 && "bg-muted/30",
+                  )}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <td
+                      key={cell.id}
+                      className="max-w-[420px] truncate px-2 py-1 align-middle font-mono text-xs"
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+            {paddingBottom > 0 && (
+              <tr>
+                <td
+                  style={{ height: paddingBottom }}
+                  colSpan={columnNames.length}
+                />
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      <Dialog
+        open={jsonCell !== null}
+        onClose={() => setJsonCell(null)}
+        title={jsonCell?.column ?? "JSON"}
+        className="max-w-2xl"
+      >
+        {jsonCell && <JsonViewer value={jsonCell.value} />}
+      </Dialog>
     </>
-  )
+  );
 }

--- a/client-next/src/components/DataGrid.tsx
+++ b/client-next/src/components/DataGrid.tsx
@@ -11,13 +11,17 @@ import {
   ArrowDown,
   ArrowUp,
   Braces,
+  ChevronDown,
   ChevronsUpDown,
+  ChevronUp,
   Key,
   Link as LinkIcon,
+  Sigma,
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import type { ColumnMeta, SortEntry } from "@/lib/api";
+import { type AggFn, AGG_LABELS, aggsForType, formatAggValue } from "@/lib/aggSql";
 import { Dialog } from "@/components/ui/dialog";
 import { JsonViewer, coerceJson, isExpandable } from "@/components/JsonViewer";
 import { CellEditor } from "@/components/CellEditor";
@@ -55,6 +59,19 @@ interface DataGridProps {
    * render FK cells as plain values (graceful degradation).
    */
   onOpenFk?: (column: string, value: unknown) => void;
+  /**
+   * Active aggregate function per column (one at a time). Providing
+   * `onAggregationChange` enables the per-column aggregations footer; omit it
+   * to hide the strip entirely (graceful degradation).
+   */
+  aggregations?: Record<string, AggFn>;
+  /** Computed aggregate value per column, keyed by column name. */
+  aggValues?: Record<string, unknown>;
+  /** True while the aggregate query is in flight. */
+  aggLoading?: boolean;
+  onAggregationChange?: (column: string, fn: AggFn | null) => void;
+  /** Read-only SQL preview for the active aggregations + filter. */
+  aggSqlPreview?: string;
 }
 
 /**
@@ -159,9 +176,20 @@ export function DataGrid({
   editable = false,
   onCommitCell,
   onOpenFk,
+  aggregations,
+  aggValues,
+  aggLoading = false,
+  onAggregationChange,
+  aggSqlPreview,
 }: DataGridProps) {
   const columnNames = useMemo(() => Object.keys(columns), [columns]);
   const [jsonCell, setJsonCell] = useState<JsonCell | null>(null);
+  const [showAggSql, setShowAggSql] = useState(false);
+
+  const aggEnabled = !!onAggregationChange;
+  const activeAggCount = aggregations
+    ? Object.keys(aggregations).length
+    : 0;
 
   // editing: which cell is in editor mode right now. Identified by row index
   // (within the current page) + column name. Switching tables/pages discards.
@@ -275,9 +303,10 @@ export function DataGrid({
 
   return (
     <>
+      <div className="flex h-full min-h-0 flex-col">
       <div
         ref={parentRef}
-        className="h-full overflow-auto rounded-md border border-border bg-card"
+        className="min-h-0 flex-1 overflow-auto rounded-md border border-border bg-card"
       >
         <table className="w-full border-collapse text-sm">
           <thead className="sticky top-0 z-10 bg-card">
@@ -436,7 +465,68 @@ export function DataGrid({
               </tr>
             )}
           </tbody>
+          {aggEnabled && (
+            <tfoot className="sticky bottom-0 z-10 bg-card">
+              <tr className="border-t border-border">
+                {columnNames.map((name) => (
+                  <td
+                    key={name}
+                    className="border-r border-border/40 px-2 py-1 align-top last:border-r-0"
+                  >
+                    <AggFooterCell
+                      meta={columns[name]}
+                      fn={aggregations?.[name] ?? null}
+                      value={aggValues?.[name]}
+                      loading={aggLoading}
+                      onChange={(fn) => onAggregationChange!(name, fn)}
+                    />
+                  </td>
+                ))}
+              </tr>
+            </tfoot>
+          )}
         </table>
+      </div>
+      {aggEnabled && activeAggCount > 0 && (
+        <div className="mt-2 shrink-0 text-sm">
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            <span className="inline-flex items-center gap-1 font-medium text-foreground">
+              <Sigma className="h-3.5 w-3.5" />
+              {activeAggCount} aggregation{activeAggCount === 1 ? "" : "s"}
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                for (const name of Object.keys(aggregations ?? {})) {
+                  onAggregationChange!(name, null);
+                }
+              }}
+              className="hover:text-foreground"
+            >
+              Clear
+            </button>
+            {aggSqlPreview && (
+              <button
+                type="button"
+                onClick={() => setShowAggSql((v) => !v)}
+                className="ml-auto inline-flex items-center gap-1 hover:text-foreground"
+              >
+                {showAggSql ? (
+                  <ChevronDown className="h-3 w-3" />
+                ) : (
+                  <ChevronUp className="h-3 w-3" />
+                )}
+                Show SQL
+              </button>
+            )}
+          </div>
+          {showAggSql && aggSqlPreview && (
+            <pre className="mt-2 overflow-x-auto rounded-md border border-border bg-card px-3 py-2 font-mono text-xs text-foreground">
+              {aggSqlPreview}
+            </pre>
+          )}
+        </div>
+      )}
       </div>
       <Dialog
         open={jsonCell !== null}
@@ -447,5 +537,59 @@ export function DataGrid({
         {jsonCell && <JsonViewer value={jsonCell.value} />}
       </Dialog>
     </>
+  );
+}
+
+/**
+ * One column's slot in the aggregations footer: a compact function picker plus
+ * the computed value. The function list is gated by the column's type, mirroring
+ * the server. Selecting the blank option clears the aggregate for that column.
+ */
+function AggFooterCell({
+  meta,
+  fn,
+  value,
+  loading,
+  onChange,
+}: {
+  meta: ColumnMeta | undefined;
+  fn: AggFn | null;
+  value: unknown;
+  loading: boolean;
+  onChange: (fn: AggFn | null) => void;
+}) {
+  const fns = useMemo(() => aggsForType(meta?.dataType), [meta?.dataType]);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <select
+        value={fn ?? ""}
+        onChange={(e) =>
+          onChange(e.target.value ? (e.target.value as AggFn) : null)
+        }
+        aria-label="Aggregate function"
+        className={cn(
+          "h-6 w-full max-w-[160px] rounded border border-transparent bg-transparent px-1 text-[11px] text-muted-foreground outline-none",
+          "hover:border-border focus:border-border",
+          fn && "text-foreground",
+        )}
+      >
+        <option value="">∑ —</option>
+        {fns.map((f) => (
+          <option key={f} value={f}>
+            {AGG_LABELS[f]}
+          </option>
+        ))}
+      </select>
+      {fn && (
+        <span className="flex items-center gap-1 truncate px-1 font-mono text-xs font-medium text-foreground">
+          {loading ? (
+            <Spinner className="h-3 w-3" aria-label="Computing" />
+          ) : (
+            formatAggValue(value)
+          )}
+        </span>
+      )}
+    </div>
   );
 }

--- a/client-next/src/components/DataGrid.tsx
+++ b/client-next/src/components/DataGrid.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   flexRender,
   getCoreRowModel,
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
+  AlertCircle,
   ArrowDown,
   ArrowUp,
   Braces,
@@ -19,14 +20,35 @@ import { cn } from "@/lib/utils";
 import type { ColumnMeta, SortEntry } from "@/lib/api";
 import { Dialog } from "@/components/ui/dialog";
 import { JsonViewer, coerceJson, isExpandable } from "@/components/JsonViewer";
+import { CellEditor } from "@/components/CellEditor";
+import { Spinner } from "@/components/ui/spinner";
 
 export type SortState = SortEntry[];
+
+/**
+ * `onCommitCell` runs the actual update. It rejects with an Error whose
+ * `.message` the grid surfaces inline next to the cell. Parents are
+ * responsible for the optimistic cache write — the grid only manages the
+ * editor/saving/error UI.
+ */
+export type CommitCell = (
+  rowIndex: number,
+  column: string,
+  newValue: unknown,
+) => Promise<void>;
 
 interface DataGridProps {
   rows: Array<Record<string, unknown>>;
   columns: Record<string, ColumnMeta>;
   sort: SortState;
   onSortChange: (next: SortState) => void;
+  /**
+   * Enables double-click-to-edit. Requires the table to have a primary key
+   * (otherwise we can't pin the UPDATE to one row). Read-only views and PK-
+   * less tables should pass false.
+   */
+  editable?: boolean;
+  onCommitCell?: CommitCell;
 }
 
 /**
@@ -104,9 +126,29 @@ function renderCell(
   }
 }
 
-export function DataGrid({ rows, columns, sort, onSortChange }: DataGridProps) {
+export function DataGrid({
+  rows,
+  columns,
+  sort,
+  onSortChange,
+  editable = false,
+  onCommitCell,
+}: DataGridProps) {
   const columnNames = useMemo(() => Object.keys(columns), [columns]);
   const [jsonCell, setJsonCell] = useState<JsonCell | null>(null);
+
+  // editing: which cell is in editor mode right now. Identified by row index
+  // (within the current page) + column name. Switching tables/pages discards.
+  const [editing, setEditing] = useState<{
+    rowIndex: number;
+    column: string;
+  } | null>(null);
+  // Cells with a save in flight. Keyed `${rowIndex}:${column}` so the same
+  // (row,col) can transition saving → ok → saving again.
+  const [saving, setSaving] = useState<Set<string>>(new Set());
+  // Last error message per cell. Cleared on next edit attempt or after a
+  // ~5s linger so the user can read it.
+  const [cellErrors, setCellErrors] = useState<Record<string, string>>({});
 
   const colDefs = useMemo<ColumnDef<Record<string, unknown>>[]>(
     () =>
@@ -145,6 +187,61 @@ export function DataGrid({ rows, columns, sort, onSortChange }: DataGridProps) {
 
   function toggleSort(name: string, additive: boolean) {
     onSortChange(nextSortState(sort, name, additive));
+  }
+
+  const canEdit = editable && !!onCommitCell;
+
+  const handleCommit = useCallback(
+    async (rowIndex: number, column: string, newValue: unknown) => {
+      const key = `${rowIndex}:${column}`;
+      setEditing(null);
+      if (!onCommitCell) return;
+      setSaving((s) => {
+        const next = new Set(s);
+        next.add(key);
+        return next;
+      });
+      setCellErrors((e) => {
+        if (!(key in e)) return e;
+        const { [key]: _drop, ...rest } = e;
+        return rest;
+      });
+      try {
+        await onCommitCell(rowIndex, column, newValue);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setCellErrors((e) => ({ ...e, [key]: message }));
+        // Clear the error after a few seconds so it doesn't linger forever.
+        setTimeout(() => {
+          setCellErrors((e) => {
+            if (e[key] !== message) return e;
+            const { [key]: _drop, ...rest } = e;
+            return rest;
+          });
+        }, 6000);
+      } finally {
+        setSaving((s) => {
+          const next = new Set(s);
+          next.delete(key);
+          return next;
+        });
+      }
+    },
+    [onCommitCell],
+  );
+
+  function tryStartEdit(rowIndex: number, column: string) {
+    if (!canEdit) return;
+    // Primary-key columns are part of the WHERE used to address the row;
+    // letting users edit them via inline editor would corrupt that mapping.
+    // (PK changes belong in a more deliberate "row edit" surface.)
+    if (columns[column]?.isPrimaryKey) return;
+    // The braces affordance on JSON cells handles its own click → opens a
+    // read-only viewer. A double-click is two clicks plus a dblclick, so the
+    // viewer may already be open. Close it before mounting the edit dialog
+    // so we don't end up with two modals stacked.
+    setJsonCell(null);
+    setEditing({ rowIndex, column });
   }
 
   return (
@@ -231,17 +328,73 @@ export function DataGrid({ rows, columns, sort, onSortChange }: DataGridProps) {
                     vr.index % 2 === 1 && "bg-muted/30",
                   )}
                 >
-                  {row.getVisibleCells().map((cell) => (
-                    <td
-                      key={cell.id}
-                      className="max-w-[420px] truncate px-2 py-1 align-middle font-mono text-xs"
-                    >
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </td>
-                  ))}
+                  {row.getVisibleCells().map((cell) => {
+                    const column = cell.column.id;
+                    const meta = columns[column];
+                    const key = `${vr.index}:${column}`;
+                    const isEditing =
+                      editing?.rowIndex === vr.index &&
+                      editing.column === column;
+                    const isSaving = saving.has(key);
+                    const error = cellErrors[key];
+                    const cellEditable =
+                      canEdit && meta != null && !meta.isPrimaryKey;
+                    return (
+                      <td
+                        key={cell.id}
+                        onDoubleClick={() => tryStartEdit(vr.index, column)}
+                        className={cn(
+                          "relative max-w-[420px] truncate px-2 py-1 align-middle font-mono text-xs",
+                          cellEditable && "cursor-text",
+                          isEditing && "overflow-visible",
+                          error &&
+                            "ring-1 ring-inset ring-destructive/60 bg-destructive/5",
+                        )}
+                        title={
+                          error
+                            ? error
+                            : cellEditable
+                              ? "Double-click to edit"
+                              : undefined
+                        }
+                      >
+                        {isEditing && meta ? (
+                          <CellEditor
+                            meta={meta}
+                            value={cell.getValue()}
+                            onCommit={(next) =>
+                              handleCommit(vr.index, column, next)
+                            }
+                            onCancel={() => setEditing(null)}
+                          />
+                        ) : (
+                          <span
+                            className={cn(
+                              "flex items-center gap-1.5",
+                              isSaving && "opacity-50",
+                            )}
+                          >
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext(),
+                            )}
+                            {isSaving && (
+                              <Spinner
+                                className="h-3 w-3 shrink-0"
+                                aria-label="Saving"
+                              />
+                            )}
+                            {error && !isSaving && (
+                              <AlertCircle
+                                className="h-3 w-3 shrink-0 text-destructive"
+                                aria-label={error}
+                              />
+                            )}
+                          </span>
+                        )}
+                      </td>
+                    );
+                  })}
                 </tr>
               );
             })}

--- a/client-next/src/components/ExportMenu.tsx
+++ b/client-next/src/components/ExportMenu.tsx
@@ -1,0 +1,224 @@
+import { useMemo, useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { ChevronDown, ChevronUp, Download } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Dialog } from '@/components/ui/dialog'
+import { Spinner } from '@/components/ui/spinner'
+import { previewWhere } from '@/lib/filterSql'
+import {
+  exportTableData,
+  type ApiError,
+  type ColumnMeta,
+  type ExportFormat,
+  type FilterGroup,
+  type SortEntry,
+} from '@/lib/api'
+
+interface ExportMenuProps {
+  connectionId: string
+  tableName: string
+  columns: Record<string, ColumnMeta>
+  filter: FilterGroup
+  sort: SortEntry[]
+}
+
+const FORMATS: { id: ExportFormat; label: string }[] = [
+  { id: 'csv', label: 'CSV' },
+  { id: 'json', label: 'JSON' },
+  { id: 'sql', label: 'SQL' },
+]
+
+function quoteIdent(name: string): string {
+  return `"${name.replaceAll('"', '""')}"`
+}
+
+function previewOrderBy(sort: SortEntry[]): string {
+  if (sort.length === 0) return ''
+  return (
+    'ORDER BY ' +
+    sort.map((s) => `${quoteIdent(s.column)} ${s.direction.toUpperCase()}`).join(', ')
+  )
+}
+
+/**
+ * "Export" toolbar action. Streams the current table view (filter + sort +
+ * chosen columns) to disk as CSV, JSON, or a SQL `INSERT` script. Honors the
+ * roadmap's "every no-code action exposes Show SQL" principle with a preview
+ * of the exact SELECT the server runs.
+ */
+export function ExportMenu({
+  connectionId,
+  tableName,
+  columns,
+  filter,
+  sort,
+}: ExportMenuProps) {
+  const allColumns = useMemo(() => Object.keys(columns), [columns])
+
+  const [open, setOpen] = useState(false)
+  const [format, setFormat] = useState<ExportFormat>('csv')
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(allColumns))
+  const [showSql, setShowSql] = useState(false)
+
+  // Preserve column order; only the chosen ones, in their ordinal order.
+  const chosen = useMemo(
+    () => allColumns.filter((c) => selected.has(c)),
+    [allColumns, selected],
+  )
+
+  const sqlPreview = useMemo(() => {
+    if (chosen.length === 0) return ''
+    const cols = chosen.map(quoteIdent).join(', ')
+    const where = previewWhere(filter)
+    const order = previewOrderBy(sort)
+    return [`SELECT ${cols}`, `FROM ${quoteIdent(tableName)}`, where, order]
+      .filter(Boolean)
+      .join('\n')
+  }, [chosen, filter, sort, tableName])
+
+  const exportMut = useMutation({
+    mutationFn: () =>
+      exportTableData(connectionId, tableName, format, {
+        filter,
+        sort,
+        columns: chosen.length === allColumns.length ? null : chosen,
+      }),
+    onSuccess: () => setOpen(false),
+  })
+
+  const toggle = (col: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(col)) next.delete(col)
+      else next.add(col)
+      return next
+    })
+
+  const allSelected = selected.size === allColumns.length
+  const error = exportMut.error as ApiError | null
+
+  return (
+    <>
+      <Button size="sm" variant="outline" onClick={() => setOpen(true)}>
+        <Download className="h-4 w-4" /> Export
+      </Button>
+
+      <Dialog
+        open={open}
+        onClose={() => {
+          if (!exportMut.isPending) setOpen(false)
+        }}
+        title={`Export ${tableName}`}
+        footer={
+          <>
+            <Button
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={exportMut.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => exportMut.mutate()}
+              disabled={chosen.length === 0 || exportMut.isPending}
+            >
+              {exportMut.isPending ? (
+                <>
+                  <Spinner className="text-xs" /> Exporting…
+                </>
+              ) : (
+                `Export ${format.toUpperCase()}`
+              )}
+            </Button>
+          </>
+        }
+      >
+        <div className="space-y-5">
+          <div>
+            <label className="mb-2 block text-sm font-medium">Format</label>
+            <div className="inline-flex rounded-md border border-border p-0.5">
+              {FORMATS.map((f) => (
+                <button
+                  key={f.id}
+                  type="button"
+                  onClick={() => setFormat(f.id)}
+                  className={
+                    'rounded px-3 py-1 text-sm transition-colors ' +
+                    (format === f.id
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:text-foreground')
+                  }
+                >
+                  {f.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <label className="text-sm font-medium">
+                Columns ({chosen.length}/{allColumns.length})
+              </label>
+              <button
+                type="button"
+                className="text-xs text-muted-foreground hover:text-foreground"
+                onClick={() =>
+                  setSelected(allSelected ? new Set() : new Set(allColumns))
+                }
+              >
+                {allSelected ? 'Deselect all' : 'Select all'}
+              </button>
+            </div>
+            <div className="max-h-48 space-y-1 overflow-y-auto rounded-md border border-border p-2">
+              {allColumns.map((col) => (
+                <label key={col} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(col)}
+                    onChange={() => toggle(col)}
+                  />
+                  <span className="truncate font-mono text-xs">{col}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Exports every row matching the current filter and sort — not just
+            the visible page.
+          </p>
+
+          {chosen.length > 0 && (
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowSql((v) => !v)}
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              >
+                {showSql ? (
+                  <ChevronUp className="h-3 w-3" />
+                ) : (
+                  <ChevronDown className="h-3 w-3" />
+                )}
+                Show SQL
+              </button>
+              {showSql && (
+                <pre className="mt-2 overflow-x-auto rounded-md border border-border bg-card px-3 py-2 font-mono text-xs text-foreground">
+                  {sqlPreview}
+                </pre>
+              )}
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
+              {error.message}
+            </div>
+          )}
+        </div>
+      </Dialog>
+    </>
+  )
+}

--- a/client-next/src/components/FilterBar.tsx
+++ b/client-next/src/components/FilterBar.tsx
@@ -1,0 +1,329 @@
+import { useMemo, useState } from 'react'
+import { ChevronDown, ChevronUp, Plus, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import type { ColumnMeta, FilterCondition, FilterGroup, FilterOp } from '@/lib/api'
+import {
+  OPERATOR_LABELS,
+  opNeedsValue,
+  opTakesArray,
+  operatorsForType,
+  previewWhere,
+} from '@/lib/filterSql'
+import { cn } from '@/lib/utils'
+
+interface FilterBarProps {
+  columns: Record<string, ColumnMeta>
+  filter: FilterGroup
+  onChange: (next: FilterGroup) => void
+}
+
+export const EMPTY_FILTER: FilterGroup = { type: 'group', combinator: 'and', children: [] }
+
+export function FilterBar({ columns, filter, onChange }: FilterBarProps) {
+  const [showSql, setShowSql] = useState(false)
+  const columnNames = useMemo(() => Object.keys(columns), [columns])
+
+  if (columnNames.length === 0) return null
+
+  const conditions = filter.children.filter(
+    (c): c is FilterCondition => c.type === 'condition',
+  )
+
+  function updateCondition(index: number, patch: Partial<FilterCondition>) {
+    const next: FilterGroup = {
+      ...filter,
+      children: filter.children.map((c, i) =>
+        i === index && c.type === 'condition' ? { ...c, ...patch } : c,
+      ),
+    }
+    onChange(next)
+  }
+
+  function removeCondition(index: number) {
+    onChange({ ...filter, children: filter.children.filter((_, i) => i !== index) })
+  }
+
+  function addCondition() {
+    const firstCol = columnNames[0]
+    const ops = operatorsForType(columns[firstCol]?.dataType)
+    const op = ops[0] ?? 'eq'
+    const next: FilterCondition = {
+      type: 'condition',
+      column: firstCol,
+      op,
+      ...(opNeedsValue(op) ? { value: '' } : {}),
+    }
+    onChange({ ...filter, children: [...filter.children, next] })
+  }
+
+  function setCombinator(combinator: 'and' | 'or') {
+    onChange({ ...filter, combinator })
+  }
+
+  function clearAll() {
+    onChange(EMPTY_FILTER)
+  }
+
+  const sqlPreview = previewWhere(filter)
+
+  return (
+    <div className="border-b border-border bg-muted/30 px-4 py-2 text-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        {conditions.length === 0 ? (
+          <span className="text-xs text-muted-foreground">No filters</span>
+        ) : (
+          <ConjunctionToggle combinator={filter.combinator} onChange={setCombinator} />
+        )}
+
+        {conditions.map((c, i) => (
+          <ConditionRow
+            key={i}
+            condition={c}
+            columns={columns}
+            columnNames={columnNames}
+            showCombinator={i > 0}
+            combinator={filter.combinator}
+            onChange={(patch) => updateCondition(i, patch)}
+            onRemove={() => removeCondition(i)}
+          />
+        ))}
+
+        <Button size="sm" variant="outline" onClick={addCondition}>
+          <Plus className="h-3.5 w-3.5" /> Add filter
+        </Button>
+
+        {conditions.length > 0 && (
+          <Button size="sm" variant="ghost" onClick={clearAll}>
+            Clear
+          </Button>
+        )}
+
+        {conditions.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowSql((v) => !v)}
+            className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {showSql ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            Show SQL
+          </button>
+        )}
+      </div>
+
+      {showSql && sqlPreview && (
+        <pre className="mt-2 overflow-x-auto rounded-md border border-border bg-card px-3 py-2 font-mono text-xs text-foreground">
+          {sqlPreview}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+function ConjunctionToggle({
+  combinator, onChange,
+}: { combinator: 'and' | 'or'; onChange: (c: 'and' | 'or') => void }) {
+  return (
+    <div className="inline-flex rounded-md border border-border bg-background text-xs">
+      {(['and', 'or'] as const).map((c) => (
+        <button
+          key={c}
+          type="button"
+          onClick={() => onChange(c)}
+          className={cn(
+            'px-2 py-1 uppercase',
+            combinator === c
+              ? 'bg-primary text-primary-foreground'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          {c}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+interface ConditionRowProps {
+  condition: FilterCondition
+  columns: Record<string, ColumnMeta>
+  columnNames: string[]
+  showCombinator: boolean
+  combinator: 'and' | 'or'
+  onChange: (patch: Partial<FilterCondition>) => void
+  onRemove: () => void
+}
+
+function ConditionRow({
+  condition, columns, columnNames, showCombinator, combinator, onChange, onRemove,
+}: ConditionRowProps) {
+  const meta = columns[condition.column]
+  const ops = useMemo(() => operatorsForType(meta?.dataType), [meta?.dataType])
+
+  function onColumnChange(name: string) {
+    const newOps = operatorsForType(columns[name]?.dataType)
+    const op = newOps.includes(condition.op) ? condition.op : (newOps[0] ?? 'eq')
+    onChange({
+      column: name,
+      op,
+      ...(opNeedsValue(op) ? { value: condition.value ?? '' } : { value: undefined }),
+    })
+  }
+
+  function onOpChange(op: FilterOp) {
+    onChange({
+      op,
+      ...(opNeedsValue(op) ? { value: condition.value ?? '' } : { value: undefined }),
+    })
+  }
+
+  return (
+    <div className="inline-flex items-stretch overflow-hidden rounded-md border border-border bg-background">
+      {showCombinator && (
+        <span className="flex items-center px-2 text-[10px] font-semibold uppercase text-muted-foreground">
+          {combinator}
+        </span>
+      )}
+
+      <Select
+        value={condition.column}
+        onChange={(e) => onColumnChange(e.target.value)}
+        className="w-40 border-0 border-r border-border"
+        aria-label="Filter column"
+      >
+        {columnNames.map((n) => (
+          <option key={n} value={n}>{n}</option>
+        ))}
+      </Select>
+
+      <Select
+        value={condition.op}
+        onChange={(e) => onOpChange(e.target.value as FilterOp)}
+        className="w-32 border-0 border-r border-border"
+        aria-label="Filter operator"
+      >
+        {ops.map((o) => (
+          <option key={o} value={o}>{OPERATOR_LABELS[o]}</option>
+        ))}
+      </Select>
+
+      {opNeedsValue(condition.op) && (
+        <ValueInput
+          condition={condition}
+          dataType={meta?.dataType}
+          onChange={(value) => onChange({ value })}
+        />
+      )}
+
+      <button
+        type="button"
+        onClick={onRemove}
+        className="flex items-center px-2 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+        aria-label="Remove filter"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  )
+}
+
+function ValueInput({
+  condition, dataType, onChange,
+}: {
+  condition: FilterCondition
+  dataType: string | undefined
+  onChange: (v: unknown) => void
+}) {
+  const t = (dataType ?? '').toLowerCase()
+
+  if (opTakesArray(condition.op)) {
+    return (
+      <Input
+        type="text"
+        value={Array.isArray(condition.value) ? condition.value.join(', ') : ''}
+        placeholder="a, b, c"
+        onChange={(e) => {
+          const parts = e.target.value
+            .split(',')
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0)
+          const coerced = /(int|numeric|decimal|real|double|serial)/.test(t)
+            ? parts.map((p) => Number(p)).filter((n) => !Number.isNaN(n))
+            : parts
+          onChange(coerced)
+        }}
+        className="h-8 w-48 rounded-none border-0 shadow-none focus-visible:ring-0"
+      />
+    )
+  }
+
+  if (condition.op === 'jsonb_contains') {
+    return (
+      <Input
+        type="text"
+        value={typeof condition.value === 'string' ? condition.value : JSON.stringify(condition.value ?? '')}
+        placeholder='{"key": "value"}'
+        onChange={(e) => onChange(e.target.value)}
+        className="h-8 w-56 rounded-none border-0 font-mono shadow-none focus-visible:ring-0"
+      />
+    )
+  }
+
+  if (t === 'boolean' || t === 'bool') {
+    return (
+      <Select
+        value={String(condition.value ?? 'true')}
+        onChange={(e) => onChange(e.target.value === 'true')}
+        className="w-24 border-0 border-r border-border"
+      >
+        <option value="true">true</option>
+        <option value="false">false</option>
+      </Select>
+    )
+  }
+
+  if (t === 'date') {
+    return (
+      <Input
+        type="date"
+        value={typeof condition.value === 'string' ? condition.value : ''}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-8 w-40 rounded-none border-0 shadow-none focus-visible:ring-0"
+      />
+    )
+  }
+
+  if (t.startsWith('timestamp')) {
+    return (
+      <Input
+        type="datetime-local"
+        value={typeof condition.value === 'string' ? condition.value : ''}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-8 w-52 rounded-none border-0 shadow-none focus-visible:ring-0"
+      />
+    )
+  }
+
+  const isNumeric = /(int|numeric|decimal|real|double|serial)/.test(t)
+  return (
+    <Input
+      type={isNumeric ? 'number' : 'text'}
+      value={condition.value == null ? '' : String(condition.value)}
+      onChange={(e) => {
+        const raw = e.target.value
+        if (isNumeric) {
+          if (raw === '') onChange('')
+          else {
+            const n = Number(raw)
+            onChange(Number.isNaN(n) ? raw : n)
+          }
+        } else {
+          onChange(raw)
+        }
+      }}
+      className="h-8 w-40 rounded-none border-0 shadow-none focus-visible:ring-0"
+    />
+  )
+}

--- a/client-next/src/components/FkPanel.tsx
+++ b/client-next/src/components/FkPanel.tsx
@@ -1,0 +1,392 @@
+import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  ExternalLink,
+  Key,
+  Link as LinkIcon,
+  Pencil,
+  X,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Loading } from "@/components/ui/spinner";
+import { CellEditor } from "@/components/CellEditor";
+import { JsonViewer, coerceJson, isExpandable } from "@/components/JsonViewer";
+import {
+  getTableData,
+  updateRow,
+  type ColumnMeta,
+  type FilterGroup,
+  type TableData,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+/**
+ * One hop in the click-through chain. We display the row living at
+ * `refTable` WHERE `refColumn` = `refValue` (the referenced row). `origin*`
+ * records where we arrived FROM, so the panel can offer "show all rows in
+ * <originTable> where <originColumn> = <originValue>" — the reverse jump back
+ * to the sibling set that shares this foreign key.
+ */
+export interface FkTarget {
+  refTable: string;
+  refColumn: string;
+  refValue: unknown;
+  originTable: string;
+  originColumn: string;
+  originValue: unknown;
+}
+
+interface FkPanelProps {
+  connectionId: string;
+  /**
+   * The first hop. The panel owns deeper chain state internally; remount it
+   * with a fresh `key` when the user clicks a different FK in the grid so the
+   * chain resets.
+   */
+  target: FkTarget;
+  onClose: () => void;
+  /** Jump to `table` with `column = value` pre-applied (opens/activates its tab). */
+  onShowReferencing: (table: string, column: string, value: unknown) => void;
+}
+
+/** Build the single-equality filter that pins the referenced row. */
+function eqFilter(column: string, value: unknown): FilterGroup {
+  return {
+    type: "group",
+    combinator: "and",
+    children: [{ type: "condition", column, op: "eq", value }],
+  };
+}
+
+function displayScalar(value: unknown): string {
+  if (value === null || value === undefined) return "NULL";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+export function FkPanel({
+  connectionId,
+  target,
+  onClose,
+  onShowReferencing,
+}: FkPanelProps) {
+  const qc = useQueryClient();
+  const [stack, setStack] = useState<FkTarget[]>([target]);
+  const [mode, setMode] = useState<"view" | "edit">("view");
+  const [editingField, setEditingField] = useState<string | null>(null);
+  const [fieldError, setFieldError] = useState<string | null>(null);
+
+  const frame = stack[stack.length - 1];
+  const depth = stack.length;
+
+  // Esc closes the panel (matching the modal-dismiss convention elsewhere).
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // Returning to view mode whenever the displayed row changes keeps a stale
+  // editor from carrying across hops.
+  useEffect(() => {
+    setMode("view");
+    setEditingField(null);
+    setFieldError(null);
+  }, [depth, frame.refTable, frame.refColumn, frame.refValue]);
+
+  const queryKey = [
+    "fkrow",
+    connectionId,
+    frame.refTable,
+    frame.refColumn,
+    frame.refValue,
+  ] as const;
+
+  const query = useQuery({
+    queryKey,
+    queryFn: ({ signal }) =>
+      getTableData(
+        connectionId,
+        frame.refTable,
+        { limit: 1, filter: eqFilter(frame.refColumn, frame.refValue) },
+        signal,
+      ),
+    enabled: !!connectionId,
+  });
+
+  const data = query.data;
+  const row = data?.rows[0];
+  const columns = data?.columns;
+  const canEdit = !!data?.hasPrimaryKey;
+
+  function followFk(fieldName: string, meta: ColumnMeta, value: unknown) {
+    if (value === null || value === undefined || !meta.foreignKeyRef) return;
+    setStack((s) => [
+      ...s,
+      {
+        refTable: meta.foreignKeyRef!.table,
+        refColumn: meta.foreignKeyRef!.column,
+        refValue: value,
+        originTable: frame.refTable,
+        originColumn: fieldName,
+        originValue: value,
+      },
+    ]);
+  }
+
+  async function commitField(column: string, newValue: unknown) {
+    if (!row || !columns) return;
+    const pkCols = Object.entries(columns)
+      .filter(([, m]) => m.isPrimaryKey)
+      .map(([name]) => name);
+    const where: Record<string, unknown> = {};
+    for (const pk of pkCols) where[pk] = row[pk];
+
+    setEditingField(null);
+    setFieldError(null);
+    try {
+      const updated = await updateRow(connectionId, frame.refTable, {
+        where,
+        set: { [column]: newValue },
+      });
+      // Server-returned row supersedes our guess (triggers/defaults/coercion).
+      qc.setQueryData<TableData>(queryKey, (cur) =>
+        cur ? { ...cur, rows: [updated] } : cur,
+      );
+      // The referenced row may also be on screen in its own table tab — drop
+      // those caches so they refetch the edited value.
+      qc.invalidateQueries({
+        queryKey: ["table", connectionId, frame.refTable],
+      });
+    } catch (err) {
+      setFieldError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <>
+      {/* Click-away backdrop. */}
+      <div
+        className="fixed inset-0 z-40 bg-black/20"
+        onClick={onClose}
+        aria-hidden
+      />
+      <aside
+        className="fixed right-0 top-0 z-50 flex h-full w-[420px] max-w-[90vw] flex-col border-l border-border bg-card shadow-2xl"
+        role="dialog"
+        aria-label={`Referenced row in ${frame.refTable}`}
+      >
+        <header className="flex items-center gap-2 border-b border-border px-4 py-3">
+          {depth > 1 && (
+            <button
+              onClick={() => setStack((s) => s.slice(0, -1))}
+              className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              aria-label="Back"
+              title="Back"
+            >
+              <ArrowLeft className="h-4 w-4" />
+            </button>
+          )}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <LinkIcon className="h-3 w-3 text-violet-500" />
+              <span className="truncate">
+                {frame.originTable}.{frame.originColumn} →
+              </span>
+            </div>
+            <h2 className="truncate font-semibold">{frame.refTable}</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-auto px-4 py-3">
+          {query.isLoading && (
+            <Loading className="text-sm text-muted-foreground">
+              Loading referenced row…
+            </Loading>
+          )}
+          {query.error && (
+            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+              {(query.error as Error).message}
+            </div>
+          )}
+          {data && !row && (
+            <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+              No row found in <span className="font-mono">{frame.refTable}</span>{" "}
+              where{" "}
+              <span className="font-mono">
+                {frame.refColumn} = {displayScalar(frame.refValue)}
+              </span>
+              . The reference may be dangling.
+            </div>
+          )}
+
+          {row && columns && (
+            <dl className="divide-y divide-border/60">
+              {Object.entries(columns).map(([name, meta]) => {
+                const value = row[name];
+                const isEditingThis = editingField === name;
+                const editableField =
+                  mode === "edit" && canEdit && !meta.isPrimaryKey;
+                return (
+                  <div key={name} className="py-2">
+                    <dt className="flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
+                      {meta.isPrimaryKey && (
+                        <Key className="h-3 w-3 text-amber-500" />
+                      )}
+                      {meta.isForeignKey && (
+                        <LinkIcon className="h-3 w-3 text-violet-500" />
+                      )}
+                      <span className="truncate">{name}</span>
+                      <span className="ml-auto lowercase text-muted-foreground/70">
+                        {meta.dataType}
+                      </span>
+                    </dt>
+                    <dd className="mt-0.5 font-mono text-xs">
+                      {isEditingThis ? (
+                        <CellEditor
+                          meta={meta}
+                          value={value}
+                          onCommit={(next) => commitField(name, next)}
+                          onCancel={() => setEditingField(null)}
+                        />
+                      ) : (
+                        <FieldValue
+                          meta={meta}
+                          value={value}
+                          editable={editableField}
+                          onEdit={() => {
+                            setFieldError(null);
+                            setEditingField(name);
+                          }}
+                          onFollow={() => followFk(name, meta, value)}
+                        />
+                      )}
+                    </dd>
+                  </div>
+                );
+              })}
+            </dl>
+          )}
+
+          {fieldError && (
+            <div className="mt-3 rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
+              {fieldError}
+            </div>
+          )}
+        </div>
+
+        <footer className="flex flex-col gap-2 border-t border-border px-4 py-3">
+          <Button
+            variant="outline"
+            size="sm"
+            className="justify-start"
+            onClick={() =>
+              onShowReferencing(
+                frame.originTable,
+                frame.originColumn,
+                frame.originValue,
+              )
+            }
+          >
+            <ExternalLink className="h-4 w-4" />
+            <span className="truncate">
+              Show all rows in {frame.originTable} where {frame.originColumn} ={" "}
+              {displayScalar(frame.originValue)}
+            </span>
+          </Button>
+          {mode === "view" ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={!canEdit}
+              title={
+                canEdit
+                  ? undefined
+                  : "Referenced table has no primary key — editing disabled"
+              }
+              onClick={() => setMode("edit")}
+            >
+              <Pencil className="h-4 w-4" /> Edit referenced row
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              onClick={() => {
+                setMode("view");
+                setEditingField(null);
+              }}
+            >
+              Done editing
+            </Button>
+          )}
+        </footer>
+      </aside>
+    </>
+  );
+}
+
+interface FieldValueProps {
+  meta: ColumnMeta;
+  value: unknown;
+  editable: boolean;
+  onEdit: () => void;
+  onFollow: () => void;
+}
+
+function FieldValue({ meta, value, editable, onEdit, onFollow }: FieldValueProps) {
+  const isNull = value === null || value === undefined;
+  const json = coerceJson(value);
+  const showJson =
+    !isNull &&
+    (meta.dataType?.toLowerCase() === "json" ||
+      meta.dataType?.toLowerCase() === "jsonb" ||
+      isExpandable(json));
+
+  const content = isNull ? (
+    <span className="italic text-muted-foreground/60">NULL</span>
+  ) : meta.isForeignKey && meta.foreignKeyRef ? (
+    <button
+      onClick={onFollow}
+      className="flex items-center gap-1 text-left text-violet-600 hover:underline dark:text-violet-400"
+      title={`Follow → ${meta.foreignKeyRef.table}.${meta.foreignKeyRef.column}`}
+    >
+      <LinkIcon className="h-3 w-3 shrink-0" />
+      <span className="break-all">{displayScalar(value)}</span>
+    </button>
+  ) : showJson ? (
+    <div className="rounded-md border border-border bg-background p-2">
+      <JsonViewer value={json} />
+    </div>
+  ) : (
+    <span className="break-all">{displayScalar(value)}</span>
+  );
+
+  if (!editable) return content;
+  return (
+    <div className="group flex items-start gap-1">
+      <div className="min-w-0 flex-1">{content}</div>
+      <button
+        onClick={onEdit}
+        className={cn(
+          "shrink-0 rounded p-0.5 text-muted-foreground opacity-0",
+          "hover:bg-accent hover:text-foreground group-hover:opacity-100",
+        )}
+        aria-label="Edit field"
+        title="Edit"
+      >
+        <Pencil className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/client-next/src/components/ImportDialog.tsx
+++ b/client-next/src/components/ImportDialog.tsx
@@ -1,0 +1,430 @@
+import { useMemo, useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { ChevronDown, ChevronUp, Upload } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Dialog } from '@/components/ui/dialog'
+import { Select } from '@/components/ui/select'
+import { Spinner } from '@/components/ui/spinner'
+import { parseCsv, type ParsedCsv } from '@/lib/csv'
+import {
+  importTableData,
+  type ApiError,
+  type ColumnMeta,
+  type ImportMode,
+  type ImportResult,
+} from '@/lib/api'
+
+interface ImportDialogProps {
+  open: boolean
+  onClose: () => void
+  connectionId: string
+  tableName: string
+  columns: Record<string, ColumnMeta>
+  /** Called after a successful (non-dry-run) import so the grid can refetch. */
+  onImported: () => void
+}
+
+const MODES: { id: ImportMode; label: string; hint: string }[] = [
+  { id: 'insert', label: 'Insert', hint: 'Plain INSERT. Fails if a row collides with an existing key.' },
+  { id: 'skip', label: 'Skip conflicts', hint: 'INSERT … ON CONFLICT DO NOTHING. Colliding rows are skipped.' },
+  { id: 'update', label: 'Update on conflict', hint: 'INSERT … ON CONFLICT … DO UPDATE. Colliding rows overwrite the existing row.' },
+]
+
+const SKIP = '__skip__'
+
+function quoteIdent(name: string): string {
+  return `"${name.replaceAll('"', '""')}"`
+}
+
+/** Case/underscore-insensitive header match for the mapping auto-guess. */
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[\s_-]+/g, '')
+}
+
+/**
+ * CSV import wizard. Parses the file in the browser, auto-maps headers to
+ * columns by name, lets the user pick a conflict mode, runs a dry run (counts
+ * + rollback), then executes inside a server-side transaction. Honors the
+ * roadmap's "Show SQL" principle with a preview of the INSERT the server runs.
+ */
+export function ImportDialog({
+  open,
+  onClose,
+  connectionId,
+  tableName,
+  columns,
+  onImported,
+}: ImportDialogProps) {
+  const tableColumns = useMemo(() => Object.keys(columns), [columns])
+  const pkColumns = useMemo(
+    () => tableColumns.filter((c) => columns[c].isPrimaryKey),
+    [tableColumns, columns],
+  )
+
+  const [fileName, setFileName] = useState<string | null>(null)
+  const [rawText, setRawText] = useState<string>('')
+  const [hasHeader, setHasHeader] = useState(true)
+  const [parsed, setParsed] = useState<ParsedCsv | null>(null)
+  const [parseError, setParseError] = useState<string | null>(null)
+
+  // target column -> CSV header index (or undefined when skipped).
+  const [mapping, setMapping] = useState<Record<string, number>>({})
+  const [mode, setMode] = useState<ImportMode>('insert')
+  const [conflictCols, setConflictCols] = useState<Set<string>>(new Set())
+  const [emptyAsNull, setEmptyAsNull] = useState(true)
+  const [showSql, setShowSql] = useState(false)
+  const [dryRun, setDryRun] = useState<ImportResult | null>(null)
+
+  const reset = () => {
+    setFileName(null)
+    setRawText('')
+    setHasHeader(true)
+    setParsed(null)
+    setParseError(null)
+    setMapping({})
+    setMode('insert')
+    setConflictCols(new Set())
+    setEmptyAsNull(true)
+    setShowSql(false)
+    setDryRun(null)
+    importMut.reset()
+  }
+
+  // (Re)parse `text` and seed the column mapping by header-name match.
+  const ingest = (text: string, header: boolean) => {
+    try {
+      const result = parseCsv(text, { hasHeader: header })
+      setParsed(result)
+      setParseError(result.rows.length === 0 ? 'No data rows found in the file.' : null)
+      const byNorm = new Map(result.headers.map((h, i) => [normalize(h), i]))
+      const guess: Record<string, number> = {}
+      for (const col of tableColumns) {
+        const hit = byNorm.get(normalize(col))
+        if (hit !== undefined) guess[col] = hit
+      }
+      setMapping(guess)
+      setConflictCols(new Set(pkColumns.filter((c) => guess[c] !== undefined)))
+      setDryRun(null)
+    } catch (err) {
+      setParsed(null)
+      setParseError(err instanceof Error ? err.message : 'Could not parse the CSV file.')
+    }
+  }
+
+  const onFile = async (file: File | undefined) => {
+    if (!file) return
+    const text = await file.text()
+    setFileName(file.name)
+    setRawText(text)
+    ingest(text, hasHeader)
+  }
+
+  const toggleHeader = (next: boolean) => {
+    setHasHeader(next)
+    if (rawText) ingest(rawText, next)
+  }
+
+  // Target columns with a source, in table-column order — the import order.
+  const mappedColumns = useMemo(
+    () => tableColumns.filter((c) => mapping[c] !== undefined),
+    [tableColumns, mapping],
+  )
+
+  // Project every parsed row down to the mapped columns, in order.
+  const projectedRows = useMemo(() => {
+    if (!parsed) return []
+    return parsed.rows.map((row) => mappedColumns.map((c) => row[mapping[c]] ?? ''))
+  }, [parsed, mappedColumns, mapping])
+
+  const effectiveConflictCols = useMemo(
+    () => mappedColumns.filter((c) => conflictCols.has(c)),
+    [mappedColumns, conflictCols],
+  )
+
+  const sqlPreview = useMemo(() => {
+    if (mappedColumns.length === 0) return ''
+    const cols = mappedColumns.map(quoteIdent).join(', ')
+    const ph = mappedColumns
+      .map((c) => {
+        const t = (columns[c].dataType || '').toLowerCase()
+        return t === 'jsonb' || t === 'json' ? `$?::${t}` : '$?'
+      })
+      .join(', ')
+    let conflict = ''
+    if (mode === 'skip') conflict = '\nON CONFLICT DO NOTHING'
+    else if (mode === 'update') {
+      const target = effectiveConflictCols.map(quoteIdent).join(', ')
+      const setCols = mappedColumns.filter((c) => !effectiveConflictCols.includes(c))
+      const setList = setCols.map((c) => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`).join(', ')
+      conflict = `\nON CONFLICT (${target || '…'}) DO ${setList ? `UPDATE SET ${setList}` : 'NOTHING'}`
+    }
+    return `INSERT INTO ${quoteIdent(tableName)} (${cols})\nVALUES (${ph})${conflict}`
+  }, [mappedColumns, columns, mode, effectiveConflictCols, tableName])
+
+  const updateNeedsConflict = mode === 'update' && effectiveConflictCols.length === 0
+  const canRun =
+    mappedColumns.length > 0 && projectedRows.length > 0 && !updateNeedsConflict
+
+  const basePayload = () => ({
+    columns: mappedColumns,
+    rows: projectedRows,
+    mode,
+    conflictColumns: mode === 'update' ? effectiveConflictCols : undefined,
+    emptyAsNull,
+  })
+
+  const dryRunMut = useMutation({
+    mutationFn: () => importTableData(connectionId, tableName, { ...basePayload(), dryRun: true }),
+    onSuccess: (r) => setDryRun(r),
+  })
+
+  const importMut = useMutation({
+    mutationFn: () => importTableData(connectionId, tableName, { ...basePayload(), dryRun: false }),
+    onSuccess: () => {
+      onImported()
+      reset()
+      onClose()
+    },
+  })
+
+  const busy = dryRunMut.isPending || importMut.isPending
+  const error = (importMut.error ?? dryRunMut.error) as ApiError | null
+
+  const close = () => {
+    if (busy) return
+    reset()
+    onClose()
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={close}
+      title={`Import into ${tableName}`}
+      className="max-w-2xl"
+      footer={
+        <>
+          <Button variant="outline" onClick={close} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => dryRunMut.mutate()}
+            disabled={!canRun || busy}
+          >
+            {dryRunMut.isPending ? (
+              <>
+                <Spinner className="text-xs" /> Checking…
+              </>
+            ) : (
+              'Dry run'
+            )}
+          </Button>
+          <Button onClick={() => importMut.mutate()} disabled={!canRun || busy}>
+            {importMut.isPending ? (
+              <>
+                <Spinner className="text-xs" /> Importing…
+              </>
+            ) : (
+              `Import ${projectedRows.length || ''} rows`
+            )}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-5">
+        {/* Step 1 — file */}
+        <div>
+          <label className="mb-2 block text-sm font-medium">CSV file</label>
+          <div className="flex items-center gap-3">
+            <label className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent">
+              <Upload className="h-4 w-4" />
+              Choose file
+              <input
+                type="file"
+                accept=".csv,text/csv,text/plain"
+                className="hidden"
+                onChange={(e) => onFile(e.target.files?.[0])}
+              />
+            </label>
+            {fileName && (
+              <span className="truncate text-xs text-muted-foreground">{fileName}</span>
+            )}
+          </div>
+          {fileName && (
+            <label className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={hasHeader}
+                onChange={(e) => toggleHeader(e.target.checked)}
+              />
+              First row is a header
+            </label>
+          )}
+          {parseError && (
+            <p className="mt-2 text-xs text-destructive">{parseError}</p>
+          )}
+        </div>
+
+        {/* Step 2 — mapping */}
+        {parsed && parsed.rows.length > 0 && (
+          <div>
+            <label className="mb-2 block text-sm font-medium">
+              Map columns ({mappedColumns.length}/{tableColumns.length}) ·{' '}
+              {parsed.rows.length.toLocaleString()} rows
+            </label>
+            <div className="max-h-56 space-y-1 overflow-y-auto rounded-md border border-border p-2">
+              {tableColumns.map((col) => (
+                <div key={col} className="flex items-center gap-2 text-sm">
+                  <span className="w-1/2 truncate font-mono text-xs">
+                    {col}
+                    <span className="ml-1 text-muted-foreground">
+                      {columns[col].dataType}
+                      {columns[col].isPrimaryKey ? ' · pk' : ''}
+                    </span>
+                  </span>
+                  <Select
+                    className="w-1/2"
+                    value={mapping[col] === undefined ? SKIP : String(mapping[col])}
+                    onChange={(e) => {
+                      const v = e.target.value
+                      setDryRun(null)
+                      setMapping((prev) => {
+                        const next = { ...prev }
+                        if (v === SKIP) delete next[col]
+                        else next[col] = Number(v)
+                        return next
+                      })
+                    }}
+                  >
+                    <option value={SKIP}>— skip —</option>
+                    {parsed.headers.map((h, i) => (
+                      <option key={i} value={i}>
+                        {h || `column_${i + 1}`}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Step 3 — mode + options */}
+        {mappedColumns.length > 0 && (
+          <>
+            <div>
+              <label className="mb-2 block text-sm font-medium">On conflict</label>
+              <div className="space-y-1">
+                {MODES.map((m) => (
+                  <label key={m.id} className="flex items-start gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="import-mode"
+                      className="mt-0.5"
+                      checked={mode === m.id}
+                      onChange={() => {
+                        setMode(m.id)
+                        setDryRun(null)
+                      }}
+                    />
+                    <span>
+                      {m.label}
+                      <span className="block text-xs text-muted-foreground">{m.hint}</span>
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {mode === 'update' && (
+              <div>
+                <label className="mb-2 block text-sm font-medium">Conflict key</label>
+                <div className="flex flex-wrap gap-3 rounded-md border border-border p-2">
+                  {mappedColumns.map((col) => (
+                    <label key={col} className="flex items-center gap-1.5 text-xs">
+                      <input
+                        type="checkbox"
+                        checked={conflictCols.has(col)}
+                        onChange={() => {
+                          setDryRun(null)
+                          setConflictCols((prev) => {
+                            const next = new Set(prev)
+                            if (next.has(col)) next.delete(col)
+                            else next.add(col)
+                            return next
+                          })
+                        }}
+                      />
+                      <span className="font-mono">{col}</span>
+                    </label>
+                  ))}
+                </div>
+                {updateNeedsConflict && (
+                  <p className="mt-1 text-xs text-destructive">
+                    Pick at least one mapped column as the conflict key (usually the
+                    primary key or a unique column).
+                  </p>
+                )}
+              </div>
+            )}
+
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={emptyAsNull}
+                onChange={(e) => {
+                  setEmptyAsNull(e.target.checked)
+                  setDryRun(null)
+                }}
+              />
+              Treat blank cells as NULL
+            </label>
+
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowSql((v) => !v)}
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              >
+                {showSql ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+                Show SQL
+              </button>
+              {showSql && (
+                <pre className="mt-2 overflow-x-auto rounded-md border border-border bg-card px-3 py-2 font-mono text-xs text-foreground">
+                  {sqlPreview}
+                </pre>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Dry-run result */}
+        {dryRun && (
+          <div className="rounded-md border border-border bg-card p-3 text-xs">
+            <p className="mb-1 font-medium">Dry run — no changes were written.</p>
+            <ul className="space-y-0.5 text-muted-foreground">
+              <li>{dryRun.attempted.toLocaleString()} rows to process</li>
+              <li>{dryRun.inserted.toLocaleString()} would be inserted</li>
+              {mode === 'update' && <li>{dryRun.updated.toLocaleString()} would be updated</li>}
+              {dryRun.conflicts > 0 && (
+                <li className={mode === 'insert' ? 'text-destructive' : undefined}>
+                  {dryRun.conflicts.toLocaleString()} conflict{dryRun.conflicts === 1 ? '' : 's'}
+                  {mode === 'insert' && ' — Insert will fail; switch to Skip or Update'}
+                </li>
+              )}
+            </ul>
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
+            {error.message}
+            {error.hint && <span className="mt-1 block opacity-80">{error.hint}</span>}
+          </div>
+        )}
+      </div>
+    </Dialog>
+  )
+}

--- a/client-next/src/components/InsertRowDialog.tsx
+++ b/client-next/src/components/InsertRowDialog.tsx
@@ -1,0 +1,512 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { ChevronDown, ChevronUp, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { Dialog } from "@/components/ui/dialog";
+import { Loading } from "@/components/ui/spinner";
+import { detectEditorKind, type EditorKind } from "@/components/CellEditor";
+import { insertRow, type ColumnMeta } from "@/lib/api";
+import { previewInsert } from "@/lib/insertSql";
+import { cn } from "@/lib/utils";
+
+/**
+ * Schema-generated row insert form (roadmap §4.5).
+ *
+ * Each column becomes a field whose widget is chosen by its Postgres type
+ * (the same `detectEditorKind` the inline cell editor uses). Every field is in
+ * one of three modes:
+ *
+ *   - **default** — the column is omitted from the INSERT so Postgres applies
+ *     its DEFAULT. Only offered for default-having columns; the default
+ *     expression is ghosted in the input.
+ *   - **null** — the column is sent as an explicit SQL NULL. Only offered for
+ *     nullable columns.
+ *   - **value** — the user-entered value is coerced by type and sent.
+ *
+ * NOT NULL columns without a default are required: they must be in `value`
+ * mode with a usable value, enforced before submit. CHECK / unique violations
+ * are left to Postgres and surface in the dialog's error banner.
+ *
+ * Foreign-key columns fall back to a plain input with a "→ table.column" hint
+ * until the FK lookup pipeline lands — graceful degradation matching §4.4.
+ */
+
+type FieldMode = "default" | "null" | "value";
+
+interface FieldState {
+  mode: FieldMode;
+  /** Raw editable string. For booleans holds "true"/"false". */
+  value: string;
+}
+
+const UUID_RE =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+function isRequired(meta: ColumnMeta): boolean {
+  return meta.isNullable === false && !meta.hasDefault;
+}
+
+function initialState(
+  columns: Record<string, ColumnMeta>,
+): Record<string, FieldState> {
+  const out: Record<string, FieldState> = {};
+  for (const [name, meta] of Object.entries(columns)) {
+    const kind = detectEditorKind(meta);
+    out[name] = {
+      // Default-having columns start ghosted; everything else starts editable.
+      mode: meta.hasDefault ? "default" : "value",
+      value: kind === "boolean" ? "false" : "",
+    };
+  }
+  return out;
+}
+
+/** Coerce one value-mode field to the JSON value sent over the wire. Throws on bad input. */
+function coerce(kind: EditorKind, raw: string): unknown {
+  const v = raw;
+  switch (kind) {
+    case "boolean":
+      return v === "true";
+    case "number": {
+      const t = v.trim();
+      if (t === "") throw new Error("Enter a number");
+      if (!/^-?\d+(\.\d+)?([eE][-+]?\d+)?$/.test(t)) {
+        throw new Error("Not a number");
+      }
+      // Send the literal string so bigint precision survives the wire.
+      return t;
+    }
+    case "uuid": {
+      if (v === "") throw new Error("Enter a UUID");
+      if (!UUID_RE.test(v)) throw new Error("Not a valid UUID");
+      return v;
+    }
+    case "json":
+    case "array": {
+      if (v.trim() === "") throw new Error("Enter JSON");
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(v);
+      } catch (err) {
+        throw new Error(`Invalid JSON: ${(err as Error).message}`);
+      }
+      if (kind === "array" && !Array.isArray(parsed)) {
+        throw new Error('Array column requires a JSON array (e.g. ["a", "b"]).');
+      }
+      return parsed;
+    }
+    case "date":
+    case "datetime":
+      if (v === "") throw new Error("Pick a date");
+      return v;
+    case "text":
+    default:
+      return v;
+  }
+}
+
+function genUuid(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const h = Array.from(bytes, (b) => b.toString(16).padStart(2, "0"));
+  return `${h.slice(0, 4).join("")}-${h.slice(4, 6).join("")}-${h.slice(6, 8).join("")}-${h.slice(8, 10).join("")}-${h.slice(10, 16).join("")}`;
+}
+
+interface InsertRowDialogProps {
+  open: boolean;
+  onClose: () => void;
+  connectionId: string;
+  tableName: string;
+  columns: Record<string, ColumnMeta>;
+  /** Called after a successful insert so the caller can refetch the grid. */
+  onInserted: () => void;
+}
+
+export function InsertRowDialog({
+  open,
+  onClose,
+  connectionId,
+  tableName,
+  columns,
+  onInserted,
+}: InsertRowDialogProps) {
+  const [fields, setFields] = useState<Record<string, FieldState>>({});
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [showSql, setShowSql] = useState(false);
+
+  // (Re)seed the form whenever it opens or the target table's columns change.
+  useEffect(() => {
+    if (!open) return;
+    setFields(initialState(columns));
+    setFieldErrors({});
+  }, [open, columns]);
+
+  function setField(name: string, patch: Partial<FieldState>) {
+    setFields((f) => ({ ...f, [name]: { ...f[name], ...patch } }));
+    if (fieldErrors[name]) {
+      setFieldErrors((e) => {
+        const { [name]: _drop, ...rest } = e;
+        return rest;
+      });
+    }
+  }
+
+  /** Build the wire payload, collecting per-field coercion errors. */
+  function buildValues(): { values: Record<string, unknown> } | null {
+    const values: Record<string, unknown> = {};
+    const errors: Record<string, string> = {};
+    for (const [name, meta] of Object.entries(columns)) {
+      const state = fields[name];
+      if (!state) continue;
+      if (state.mode === "default") {
+        if (isRequired(meta)) errors[name] = "Required — provide a value";
+        continue;
+      }
+      if (state.mode === "null") {
+        if (meta.isNullable === false) errors[name] = "Column is NOT NULL";
+        else values[name] = null;
+        continue;
+      }
+      // value mode
+      const kind = detectEditorKind(meta);
+      try {
+        values[name] = coerce(kind, state.value);
+      } catch (err) {
+        errors[name] = (err as Error).message;
+      }
+    }
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return null;
+    }
+    return { values };
+  }
+
+  // Preview reflects only fields that would actually be sent. Mirror the
+  // submit logic but skip rows that currently error so the SQL stays readable.
+  const previewSql = useMemo(() => {
+    if (!showSql) return "";
+    const values: Record<string, unknown> = {};
+    for (const [name, meta] of Object.entries(columns)) {
+      const state = fields[name];
+      if (!state || state.mode === "default") continue;
+      if (state.mode === "null") {
+        values[name] = null;
+        continue;
+      }
+      try {
+        values[name] = coerce(detectEditorKind(meta), state.value);
+      } catch {
+        // Skip not-yet-valid fields in the preview.
+      }
+    }
+    return previewInsert(tableName, values, columns);
+  }, [showSql, fields, columns, tableName]);
+
+  const mutation = useMutation({
+    mutationFn: (payload: { values: Record<string, unknown> }) =>
+      insertRow(connectionId, tableName, payload),
+  });
+
+  function submit(keepOpen: boolean) {
+    const payload = buildValues();
+    if (!payload) return;
+    mutation.mutate(payload, {
+      onSuccess: () => {
+        onInserted();
+        if (keepOpen) {
+          setFields(initialState(columns));
+          setFieldErrors({});
+        } else {
+          onClose();
+        }
+      },
+    });
+  }
+
+  const busy = mutation.isPending;
+  const colEntries = Object.entries(columns);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => {
+        if (!busy) onClose();
+      }}
+      title={`Insert row into ${tableName}`}
+      className="max-w-2xl"
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={() => setShowSql((v) => !v)}
+            className="mr-auto inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {showSql ? (
+              <ChevronUp className="h-3 w-3" />
+            ) : (
+              <ChevronDown className="h-3 w-3" />
+            )}
+            Show SQL
+          </button>
+          <Button variant="outline" size="sm" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => submit(true)}
+            disabled={busy}
+            title="Insert and keep this form open for another row"
+          >
+            Insert &amp; add another
+          </Button>
+          <Button size="sm" onClick={() => submit(false)} disabled={busy}>
+            {busy ? <Loading>Inserting…</Loading> : "Insert"}
+          </Button>
+        </>
+      }
+    >
+      {mutation.error && (
+        <div className="mb-3 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {(mutation.error as Error).message}
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {colEntries.map(([name, meta]) => (
+          <InsertField
+            key={name}
+            name={name}
+            meta={meta}
+            state={fields[name] ?? { mode: "value", value: "" }}
+            error={fieldErrors[name]}
+            onChange={(patch) => setField(name, patch)}
+          />
+        ))}
+        {colEntries.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No columns — this table will insert a default row.
+          </p>
+        )}
+      </div>
+
+      {showSql && previewSql && (
+        <pre className="mt-3 overflow-x-auto rounded-md border border-border bg-card px-3 py-2 font-mono text-xs text-foreground">
+          {previewSql}
+        </pre>
+      )}
+    </Dialog>
+  );
+}
+
+// ---- Per-column field ------------------------------------------------------
+
+interface InsertFieldProps {
+  name: string;
+  meta: ColumnMeta;
+  state: FieldState;
+  error?: string;
+  onChange: (patch: Partial<FieldState>) => void;
+}
+
+function InsertField({ name, meta, state, error, onChange }: InsertFieldProps) {
+  const kind = detectEditorKind(meta);
+  const required = isRequired(meta);
+  const disabled = state.mode !== "value";
+
+  const placeholder =
+    state.mode === "default"
+      ? meta.defaultValue
+        ? `DEFAULT ${meta.defaultValue}`
+        : "DEFAULT"
+      : state.mode === "null"
+        ? "NULL"
+        : undefined;
+
+  return (
+    <div className="grid grid-cols-[minmax(0,11rem)_1fr] items-start gap-3">
+      <label className="pt-1.5 text-sm">
+        <span className="font-medium">{name}</span>
+        {required && <span className="text-destructive"> *</span>}
+        <span className="mt-0.5 flex flex-wrap items-center gap-1 text-[10px] text-muted-foreground">
+          <span className="font-mono">{meta.dataType}</span>
+          {meta.isPrimaryKey && <Badge>PK</Badge>}
+          {meta.isForeignKey && meta.foreignKeyRef && (
+            <Badge title="Foreign key">
+              → {meta.foreignKeyRef.table}.{meta.foreignKeyRef.column}
+            </Badge>
+          )}
+        </span>
+      </label>
+
+      <div className="min-w-0">
+        <div className="flex items-center gap-1">
+          <FieldWidget
+            kind={kind}
+            meta={meta}
+            value={state.value}
+            disabled={disabled}
+            placeholder={placeholder}
+            onChange={(value) => onChange({ mode: "value", value })}
+          />
+          {meta.hasDefault && (
+            <ModeButton
+              active={state.mode === "default"}
+              title={meta.defaultValue ?? "Use column default"}
+              // Toggle back to value mode so the input becomes editable again.
+              onClick={() =>
+                onChange({ mode: state.mode === "default" ? "value" : "default" })
+              }
+            >
+              DEFAULT
+            </ModeButton>
+          )}
+          {meta.isNullable && (
+            <ModeButton
+              active={state.mode === "null"}
+              title="Set to SQL NULL"
+              onClick={() =>
+                onChange({ mode: state.mode === "null" ? "value" : "null" })
+              }
+            >
+              ∅
+            </ModeButton>
+          )}
+        </div>
+        {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
+      </div>
+    </div>
+  );
+}
+
+interface WidgetProps {
+  kind: EditorKind;
+  meta: ColumnMeta;
+  value: string;
+  disabled: boolean;
+  placeholder?: string;
+  onChange: (value: string) => void;
+}
+
+function FieldWidget({ kind, value, disabled, placeholder, onChange }: WidgetProps) {
+  if (kind === "boolean") {
+    return (
+      <Select
+        value={disabled ? "" : value || "false"}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full"
+      >
+        {disabled && <option value="">{placeholder}</option>}
+        <option value="true">true</option>
+        <option value="false">false</option>
+      </Select>
+    );
+  }
+
+  if (kind === "json" || kind === "array") {
+    return (
+      <textarea
+        value={value}
+        disabled={disabled}
+        placeholder={placeholder ?? (kind === "json" ? '{ "key": "value" }' : '["a", "b"]')}
+        spellCheck={false}
+        onChange={(e) => onChange(e.target.value)}
+        className="min-h-[60px] w-full resize-y rounded-md border border-input bg-background p-2 font-mono text-xs disabled:cursor-not-allowed disabled:opacity-50"
+      />
+    );
+  }
+
+  if (kind === "uuid") {
+    return (
+      <div className="flex w-full items-center gap-1">
+        <Input
+          value={value}
+          disabled={disabled}
+          placeholder={placeholder ?? "00000000-0000-0000-0000-000000000000"}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-8 font-mono text-xs"
+        />
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => onChange(genUuid())}
+          title="Generate UUID v4"
+          className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:text-foreground disabled:opacity-50"
+        >
+          <Sparkles className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    );
+  }
+
+  const inputType =
+    kind === "date" ? "date" : kind === "datetime" ? "datetime-local" : "text";
+
+  return (
+    <Input
+      type={inputType}
+      step={kind === "datetime" ? 1 : undefined}
+      inputMode={kind === "number" ? "decimal" : undefined}
+      value={value}
+      disabled={disabled}
+      placeholder={placeholder}
+      onChange={(e) => onChange(e.target.value)}
+      className="h-8 text-xs"
+    />
+  );
+}
+
+function ModeButton({
+  active,
+  title,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  title?: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={cn(
+        "shrink-0 rounded-md border px-1.5 py-1 text-[10px] font-medium uppercase",
+        active
+          ? "border-primary bg-primary/10 text-primary"
+          : "border-border text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Badge({
+  children,
+  title,
+}: {
+  children: React.ReactNode;
+  title?: string;
+}) {
+  return (
+    <span
+      title={title}
+      className="rounded-sm bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground"
+    >
+      {children}
+    </span>
+  );
+}

--- a/client-next/src/components/Sidebar.tsx
+++ b/client-next/src/components/Sidebar.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Link, useMatchRoute, useNavigate } from '@tanstack/react-router'
 import {
-  Download, Eye, GitBranch, MoreVertical, Pencil, Plus, Power,
-  Search, Table as TableIcon, Terminal,
+  Link, useMatchRoute, useNavigate, useRouterState,
+} from '@tanstack/react-router'
+import {
+  Bookmark, ChevronDown, ChevronRight, Download, Eye, GitBranch,
+  MoreVertical, Pencil, Plus, Power, Search, Table as TableIcon, Terminal,
 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -15,7 +17,7 @@ import { ExportProgressToast } from '@/components/ExportProgressToast'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import {
   disconnect, downloadBackup, listConnections, listSchemas, listTables,
-  patchSchema, type Connection,
+  listViews, patchSchema, type Connection, type SavedView,
 } from '@/lib/api'
 import { cn } from '@/lib/utils'
 import { useConnectionStore } from '@/store/connection'
@@ -27,6 +29,12 @@ export function Sidebar() {
   const setActive = useConnectionStore((s) => s.setActive)
   const navigate = useNavigate()
   const matchRoute = useMatchRoute()
+  // Active view id is sourced from URL search params so the nested sidebar
+  // entry highlights without needing a window.location peek.
+  const activeViewId = useRouterState({
+    select: (s) =>
+      (s.location.search as { view?: string } | undefined)?.view ?? null,
+  })
   const openTab = useTabsStore((s) => s.open)
 
   const connections = useQuery({
@@ -51,6 +59,36 @@ export function Sidebar() {
     queryFn: ({ signal }) => listSchemas(resolvedActiveId!, signal).then((r) => r.schemas),
     enabled: !!resolvedActiveId,
   })
+
+  // One bulk fetch per connection. The TableView page also reads this cache
+  // entry (`['views', connectionId, tableName]` filtered), so we keep this
+  // un-filtered fetch separate but share the connection cache via the
+  // TanStack Query cache.
+  const allViews = useQuery({
+    queryKey: ['views', resolvedActiveId],
+    queryFn: ({ signal }) =>
+      listViews({ connectionId: resolvedActiveId! }, signal).then((r) => r.views),
+    enabled: !!resolvedActiveId,
+  })
+
+  const viewsByTable = useMemo(() => {
+    const out: Record<string, SavedView[]> = {}
+    for (const v of allViews.data ?? []) {
+      (out[v.tableName] ??= []).push(v)
+    }
+    return out
+  }, [allViews.data])
+
+  // Tables that the user has expanded to reveal their nested views. Kept
+  // local — collapsing is a UI affordance, not durable state.
+  const [expandedTables, setExpandedTables] = useState<Set<string>>(new Set())
+  const toggleExpanded = (name: string) =>
+    setExpandedTables((prev) => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
 
   const patchSchemaMut = useMutation({
     mutationFn: ({ id, schema }: { id: string; schema: string }) =>
@@ -281,25 +319,79 @@ export function Sidebar() {
             {filteredTables.map((t) => {
               const params = { tableName: t.name }
               const isActive = !!matchRoute({ to: '/tables/$tableName', params })
+              const tableViews = viewsByTable[t.name] ?? []
+              const expanded = expandedTables.has(t.name)
+              const hasViews = tableViews.length > 0
               return (
                 <li key={t.name}>
-                  <button
-                    onClick={() => {
-                      openTab({ kind: 'table', tableName: t.name })
-                      navigate({ to: '/tables/$tableName', params })
-                    }}
+                  <div
                     className={cn(
-                      'flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-sm hover:bg-accent',
+                      'group flex items-center gap-0.5 rounded-md hover:bg-accent',
                       isActive && 'bg-accent text-accent-foreground',
                     )}
                   >
-                    {t.type === 'view' ? (
-                      <Eye className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                    ) : (
-                      <TableIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                    )}
-                    <span className="truncate">{t.name}</span>
-                  </button>
+                    <button
+                      aria-label={expanded ? 'Collapse views' : 'Expand views'}
+                      onClick={() => toggleExpanded(t.name)}
+                      className={cn(
+                        'flex h-6 w-4 shrink-0 items-center justify-center text-muted-foreground',
+                        !hasViews && 'invisible',
+                      )}
+                    >
+                      {expanded ? (
+                        <ChevronDown className="h-3 w-3" />
+                      ) : (
+                        <ChevronRight className="h-3 w-3" />
+                      )}
+                    </button>
+                    <button
+                      onClick={() => {
+                        openTab({ kind: 'table', tableName: t.name })
+                        navigate({ to: '/tables/$tableName', params })
+                      }}
+                      className="flex flex-1 items-center gap-2 rounded-md py-1 pr-2 text-left text-sm"
+                    >
+                      {t.type === 'view' ? (
+                        <Eye className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      ) : (
+                        <TableIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      )}
+                      <span className="truncate">{t.name}</span>
+                      {hasViews && (
+                        <span className="ml-auto rounded bg-muted px-1.5 text-[10px] text-muted-foreground">
+                          {tableViews.length}
+                        </span>
+                      )}
+                    </button>
+                  </div>
+                  {expanded && hasViews && (
+                    <ul className="ml-6 mt-0.5 space-y-0.5 border-l border-border pl-2">
+                      {tableViews.map((v) => {
+                        const isViewActive = isActive && activeViewId === v.id
+                        return (
+                          <li key={v.id}>
+                            <button
+                              onClick={() => {
+                                openTab({ kind: 'table', tableName: t.name })
+                                navigate({
+                                  to: '/tables/$tableName',
+                                  params,
+                                  search: { view: v.id },
+                                })
+                              }}
+                              className={cn(
+                                'flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-xs hover:bg-accent',
+                                isViewActive && 'bg-accent text-accent-foreground',
+                              )}
+                            >
+                              <Bookmark className="h-3 w-3 shrink-0 text-muted-foreground" />
+                              <span className="truncate">{v.name}</span>
+                            </button>
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  )}
                 </li>
               )
             })}

--- a/client-next/src/components/Sidebar.tsx
+++ b/client-next/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   Link, useMatchRoute, useNavigate, useRouterState,
@@ -47,6 +47,16 @@ export function Sidebar() {
     activeId && connections.data?.some((c) => c.id === activeId)
       ? activeId
       : connections.data?.[0]?.id ?? null
+
+  // The sidebar resolves a fallback connection (first available) for its own
+  // UI, but pages like TableView read `activeConnectionId` straight from the
+  // store. On a fresh deep-link load that value is null/stale, so persist the
+  // resolved id back to the store to keep every consumer in sync.
+  useEffect(() => {
+    if (resolvedActiveId && resolvedActiveId !== activeId) {
+      setActive(resolvedActiveId)
+    }
+  }, [resolvedActiveId, activeId, setActive])
 
   const tables = useQuery({
     queryKey: ['tables', resolvedActiveId],

--- a/client-next/src/components/SortBar.tsx
+++ b/client-next/src/components/SortBar.tsx
@@ -1,0 +1,239 @@
+import { useMemo, useRef, useState } from 'react'
+import { ArrowDown, ArrowUp, ChevronDown, ChevronUp, GripVertical, Plus, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Select } from '@/components/ui/select'
+import type { ColumnMeta, SortEntry } from '@/lib/api'
+import { cn } from '@/lib/utils'
+
+interface SortBarProps {
+  columns: Record<string, ColumnMeta>
+  sort: SortEntry[]
+  onChange: (next: SortEntry[]) => void
+}
+
+const MAX_SORTS = 10
+
+export function SortBar({ columns, sort, onChange }: SortBarProps) {
+  const [showSql, setShowSql] = useState(false)
+  const columnNames = useMemo(() => Object.keys(columns), [columns])
+
+  // Names not yet in the sort list — used to populate the "+ Add sort" picker.
+  const available = columnNames.filter((n) => !sort.some((s) => s.column === n))
+
+  if (columnNames.length === 0) return null
+
+  function update(index: number, patch: Partial<SortEntry>) {
+    onChange(sort.map((s, i) => (i === index ? { ...s, ...patch } : s)))
+  }
+
+  function remove(index: number) {
+    onChange(sort.filter((_, i) => i !== index))
+  }
+
+  function add(column: string) {
+    if (!column) return
+    onChange([...sort, { column, direction: 'asc' }])
+  }
+
+  function reorder(from: number, to: number) {
+    if (from === to || from < 0 || to < 0 || from >= sort.length || to >= sort.length) return
+    const next = [...sort]
+    const [moved] = next.splice(from, 1)
+    next.splice(to, 0, moved)
+    onChange(next)
+  }
+
+  function clearAll() {
+    onChange([])
+  }
+
+  const sqlPreview = previewOrderBy(sort)
+
+  return (
+    <div className="border-b border-border bg-muted/20 px-4 py-2 text-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Sort
+        </span>
+
+        {sort.length === 0 ? (
+          <span className="text-xs text-muted-foreground">No sort</span>
+        ) : (
+          sort.map((entry, i) => (
+            <SortChip
+              key={`${entry.column}-${i}`}
+              entry={entry}
+              index={i}
+              showPriority={sort.length > 1}
+              onDirectionChange={(direction) => update(i, { direction })}
+              onRemove={() => remove(i)}
+              onReorder={reorder}
+            />
+          ))
+        )}
+
+        {available.length > 0 && sort.length < MAX_SORTS && (
+          <AddSortPicker columns={available} onAdd={add} />
+        )}
+
+        {sort.length > 0 && (
+          <Button size="sm" variant="ghost" onClick={clearAll}>
+            Clear
+          </Button>
+        )}
+
+        {sort.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowSql((v) => !v)}
+            className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {showSql ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            Show SQL
+          </button>
+        )}
+      </div>
+
+      {showSql && sqlPreview && (
+        <pre className="mt-2 overflow-x-auto rounded-md border border-border bg-card px-3 py-2 font-mono text-xs text-foreground">
+          {sqlPreview}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+interface SortChipProps {
+  entry: SortEntry
+  index: number
+  showPriority: boolean
+  onDirectionChange: (d: 'asc' | 'desc') => void
+  onRemove: () => void
+  onReorder: (from: number, to: number) => void
+}
+
+function SortChip({
+  entry, index, showPriority, onDirectionChange, onRemove, onReorder,
+}: SortChipProps) {
+  const [dragOver, setDragOver] = useState(false)
+  const dragRef = useRef<HTMLDivElement>(null)
+
+  return (
+    <div
+      ref={dragRef}
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.effectAllowed = 'move'
+        e.dataTransfer.setData('text/plain', String(index))
+      }}
+      onDragOver={(e) => {
+        // Must preventDefault so the drop event fires; data is set by the
+        // dragged chip, so we don't read it during dragover.
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'move'
+        if (!dragOver) setDragOver(true)
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={(e) => {
+        e.preventDefault()
+        setDragOver(false)
+        const from = Number(e.dataTransfer.getData('text/plain'))
+        if (!Number.isNaN(from)) onReorder(from, index)
+      }}
+      className={cn(
+        'inline-flex items-stretch overflow-hidden rounded-md border bg-background transition-shadow',
+        dragOver ? 'border-primary ring-2 ring-primary/30' : 'border-border',
+      )}
+      aria-label={`Sort ${index + 1}: ${entry.column} ${entry.direction}`}
+    >
+      <span
+        className="flex cursor-grab items-center px-1.5 text-muted-foreground hover:bg-muted active:cursor-grabbing"
+        title="Drag to reorder priority"
+      >
+        <GripVertical className="h-3.5 w-3.5" />
+      </span>
+
+      {showPriority && (
+        <span className="flex items-center bg-primary/10 px-1.5 text-[10px] font-semibold text-primary">
+          {index + 1}
+        </span>
+      )}
+
+      <span className="flex items-center px-2 text-xs font-medium">
+        {entry.column}
+      </span>
+
+      <button
+        type="button"
+        onClick={() =>
+          onDirectionChange(entry.direction === 'asc' ? 'desc' : 'asc')
+        }
+        title={`Direction: ${entry.direction.toUpperCase()} (click to toggle)`}
+        className="flex items-center gap-1 border-l border-border px-2 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        {entry.direction === 'asc' ? (
+          <ArrowUp className="h-3 w-3" />
+        ) : (
+          <ArrowDown className="h-3 w-3" />
+        )}
+        <span className="uppercase">{entry.direction}</span>
+      </button>
+
+      <button
+        type="button"
+        onClick={onRemove}
+        className="flex items-center border-l border-border px-2 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+        aria-label="Remove sort"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  )
+}
+
+function AddSortPicker({
+  columns, onAdd,
+}: { columns: string[]; onAdd: (name: string) => void }) {
+  // A Select that resets after each pick — uses an empty placeholder option
+  // so the same column can be added later if removed.
+  const [value, setValue] = useState('')
+  return (
+    <div className="inline-flex items-center gap-1">
+      <Select
+        value={value}
+        onChange={(e) => {
+          const v = e.target.value
+          if (v) {
+            onAdd(v)
+            setValue('')
+          }
+        }}
+        className="h-8 w-44"
+        aria-label="Add sort column"
+      >
+        <option value="">+ Add sort…</option>
+        {columns.map((n) => (
+          <option key={n} value={n}>
+            {n}
+          </option>
+        ))}
+      </Select>
+      <Plus className="h-3.5 w-3.5 text-muted-foreground" />
+    </div>
+  )
+}
+
+/**
+ * Render the sort spec as a human-readable ORDER BY clause. Display-only;
+ * the server quotes identifiers itself when building the actual query.
+ */
+function previewOrderBy(sort: SortEntry[]): string {
+  if (sort.length === 0) return ''
+  return (
+    'ORDER BY ' +
+    sort
+      .map((s) => `"${s.column.replaceAll('"', '""')}" ${s.direction.toUpperCase()}`)
+      .join(', ')
+  )
+}

--- a/client-next/src/components/ViewBar.tsx
+++ b/client-next/src/components/ViewBar.tsx
@@ -1,0 +1,298 @@
+import { useEffect, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Bookmark, Check, ChevronDown, Plus, Save, Trash2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Dialog } from '@/components/ui/dialog'
+import { Dropdown, DropdownItem } from '@/components/ui/dropdown'
+import { Input } from '@/components/ui/input'
+import { Spinner } from '@/components/ui/spinner'
+import {
+  createView, deleteView, listViews, updateView,
+  type FilterGroup, type SavedView, type SortEntry,
+} from '@/lib/api'
+import { cn } from '@/lib/utils'
+
+interface ViewBarProps {
+  connectionId: string
+  tableName: string
+  /** `null` means the synthetic "All rows" default. */
+  selectedViewId: string | null
+  onSelectView: (id: string | null) => void
+  filter: FilterGroup
+  sort: SortEntry[]
+}
+
+/**
+ * Two snapshots are "equivalent" when the JSON-stringified payload matches.
+ * The filter/sort UI keeps these in a canonical shape (FilterGroup with `and`
+ * combinator at the root, sort entries lowercase) so stringify is enough —
+ * we don't need a structural deep-equal here.
+ */
+function isSameSnapshot(
+  a: { filter?: unknown; sort?: unknown },
+  b: { filter?: unknown; sort?: unknown },
+): boolean {
+  if (JSON.stringify(a.filter ?? null) !== JSON.stringify(b.filter ?? null)) {
+    return false
+  }
+  return JSON.stringify(a.sort ?? []) === JSON.stringify(b.sort ?? [])
+}
+
+export function ViewBar({
+  connectionId, tableName, selectedViewId, onSelectView, filter, sort,
+}: ViewBarProps) {
+  const qc = useQueryClient()
+  const viewsKey = ['views', connectionId, tableName] as const
+
+  const viewsQuery = useQuery({
+    queryKey: viewsKey,
+    queryFn: ({ signal }) =>
+      listViews({ connectionId, tableName }, signal).then((r) => r.views),
+  })
+
+  const selected: SavedView | null =
+    viewsQuery.data?.find((v) => v.id === selectedViewId) ?? null
+
+  // "Dirty" = the working filter/sort no longer matches the saved view (or,
+  // for the default, has any state at all). Drives the Save button enabled
+  // state + a small dot next to the view name.
+  const dirty = selected
+    ? !isSameSnapshot({ filter, sort }, selected)
+    : filter.children.length > 0 || sort.length > 0
+
+  const createMut = useMutation({
+    mutationFn: (name: string) =>
+      createView({ connectionId, tableName, name, filter, sort }),
+    onSuccess: (v) => {
+      qc.invalidateQueries({ queryKey: ['views'] })
+      onSelectView(v.id)
+    },
+  })
+
+  const updateMut = useMutation({
+    mutationFn: (id: string) => updateView(id, { filter, sort }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['views'] }),
+  })
+
+  const renameMut = useMutation({
+    mutationFn: ({ id, name }: { id: string; name: string }) =>
+      updateView(id, { name }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['views'] }),
+  })
+
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => deleteView(id),
+    onSuccess: (_d, id) => {
+      qc.invalidateQueries({ queryKey: ['views'] })
+      if (selectedViewId === id) onSelectView(null)
+    },
+  })
+
+  const [saveAsOpen, setSaveAsOpen] = useState(false)
+  const [renameOpen, setRenameOpen] = useState(false)
+
+  const lastError =
+    (createMut.error as Error | null)?.message
+    ?? (updateMut.error as Error | null)?.message
+    ?? (renameMut.error as Error | null)?.message
+    ?? (deleteMut.error as Error | null)?.message
+    ?? null
+
+  return (
+    <div className="flex items-center gap-2 border-b border-border bg-background/60 px-4 py-1.5">
+      <Bookmark className="h-3.5 w-3.5 text-muted-foreground" />
+
+      <Dropdown
+        align="start"
+        trigger={({ open }) => (
+          <span
+            className={cn(
+              'inline-flex h-7 items-center gap-1.5 rounded-md border border-border px-2 text-xs hover:bg-accent',
+              open && 'bg-accent',
+            )}
+          >
+            <span className="max-w-[200px] truncate">
+              {selected?.name ?? 'All rows'}
+            </span>
+            {dirty && (
+              <span
+                title="Unsaved changes"
+                className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
+              />
+            )}
+            <ChevronDown className="h-3 w-3 text-muted-foreground" />
+          </span>
+        )}
+        className="w-64"
+      >
+        <DropdownItem onClick={() => onSelectView(null)}>
+          <span className="flex w-full items-center justify-between">
+            <span>All rows</span>
+            {selectedViewId === null && <Check className="h-3.5 w-3.5" />}
+          </span>
+        </DropdownItem>
+        {viewsQuery.data && viewsQuery.data.length > 0 && (
+          <div className="my-1 border-t border-border" />
+        )}
+        {viewsQuery.data?.map((v) => (
+          <DropdownItem key={v.id} onClick={() => onSelectView(v.id)}>
+            <span className="flex w-full items-center justify-between gap-2">
+              <span className="truncate">{v.name}</span>
+              {selectedViewId === v.id && (
+                <Check className="h-3.5 w-3.5 shrink-0" />
+              )}
+            </span>
+          </DropdownItem>
+        ))}
+        {viewsQuery.isLoading && (
+          <div className="px-2 py-1.5 text-xs text-muted-foreground">
+            <Spinner aria-label="Loading views" /> Loading…
+          </div>
+        )}
+      </Dropdown>
+
+      <div className="ml-1 flex items-center gap-1">
+        {selected && (
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={!dirty || updateMut.isPending}
+            onClick={() => updateMut.mutate(selected.id)}
+            title={dirty ? `Save changes to "${selected.name}"` : 'No unsaved changes'}
+          >
+            <Save className="mr-1 h-3.5 w-3.5" />
+            Save
+          </Button>
+        )}
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => setSaveAsOpen(true)}
+          title="Save current filter, sort as a new view"
+        >
+          <Plus className="mr-1 h-3.5 w-3.5" />
+          Save as…
+        </Button>
+        {selected && (
+          <>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setRenameOpen(true)}
+              title={`Rename "${selected.name}"`}
+            >
+              Rename
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                if (window.confirm(`Delete view "${selected.name}"?`)) {
+                  deleteMut.mutate(selected.id)
+                }
+              }}
+              title={`Delete "${selected.name}"`}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </>
+        )}
+      </div>
+
+      {lastError && (
+        <span className="ml-auto truncate text-xs text-destructive" title={lastError}>
+          {lastError}
+        </span>
+      )}
+
+      <NameDialog
+        open={saveAsOpen}
+        title="Save view"
+        label="View name"
+        confirmLabel="Save"
+        pending={createMut.isPending}
+        onSubmit={(name) => {
+          createMut.mutate(name, {
+            onSuccess: () => setSaveAsOpen(false),
+          })
+        }}
+        onClose={() => setSaveAsOpen(false)}
+      />
+      <NameDialog
+        open={renameOpen}
+        title="Rename view"
+        label="New name"
+        confirmLabel="Rename"
+        initialValue={selected?.name ?? ''}
+        pending={renameMut.isPending}
+        onSubmit={(name) => {
+          if (!selected) return
+          renameMut.mutate(
+            { id: selected.id, name },
+            { onSuccess: () => setRenameOpen(false) },
+          )
+        }}
+        onClose={() => setRenameOpen(false)}
+      />
+    </div>
+  )
+}
+
+interface NameDialogProps {
+  open: boolean
+  title: string
+  label: string
+  confirmLabel: string
+  initialValue?: string
+  pending?: boolean
+  onSubmit: (name: string) => void
+  onClose: () => void
+}
+
+function NameDialog({
+  open, title, label, confirmLabel, initialValue = '', pending, onSubmit, onClose,
+}: NameDialogProps) {
+  const [name, setName] = useState(initialValue)
+  // Reset the input when the dialog reopens so a previous attempt doesn't
+  // leak into a fresh save.
+  useEffect(() => {
+    if (open) setName(initialValue)
+  }, [open, initialValue])
+
+  const trimmed = name.trim()
+  const canSubmit = trimmed.length > 0 && !pending
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={title}
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose}>Cancel</Button>
+          <Button
+            disabled={!canSubmit}
+            onClick={() => canSubmit && onSubmit(trimmed)}
+          >
+            {pending ? <Spinner aria-label="Saving" /> : confirmLabel}
+          </Button>
+        </>
+      }
+    >
+      <label className="block">
+        <span className="text-xs font-medium text-muted-foreground">{label}</span>
+        <Input
+          autoFocus
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && canSubmit) onSubmit(trimmed)
+          }}
+          placeholder="e.g. Open orders"
+          className="mt-1"
+        />
+      </label>
+    </Dialog>
+  )
+}

--- a/client-next/src/index.css
+++ b/client-next/src/index.css
@@ -28,26 +28,28 @@
   }
 
   .dark {
+    /* Off-black: neutral dark grays (hue 0, sat 0), never pure #000.
+       Background ~#161616, surfaces lift slightly for depth. */
     color-scheme: dark;
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --background: 0 0% 9%;
+    --foreground: 0 0% 95%;
+    --card: 0 0% 11%;
+    --card-foreground: 0 0% 95%;
+    --popover: 0 0% 11%;
+    --popover-foreground: 0 0% 95%;
+    --primary: 0 0% 95%;
+    --primary-foreground: 0 0% 11%;
+    --secondary: 0 0% 16%;
+    --secondary-foreground: 0 0% 95%;
+    --muted: 0 0% 16%;
+    --muted-foreground: 0 0% 64%;
+    --accent: 0 0% 16%;
+    --accent-foreground: 0 0% 95%;
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --destructive-foreground: 0 0% 95%;
+    --border: 0 0% 18%;
+    --input: 0 0% 18%;
+    --ring: 0 0% 70%;
   }
 
   html,

--- a/client-next/src/lib/aggSql.ts
+++ b/client-next/src/lib/aggSql.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-column aggregation helpers: which functions a column type supports, their
+ * labels, value formatting, and a client-side mirror of the SELECT the server
+ * builds (for the read-only "Show SQL" preview). The server is the source of
+ * truth and re-derives everything; the preview never executes.
+ */
+
+import type { FilterGroup } from '@/lib/api'
+import { previewWhere } from '@/lib/filterSql'
+
+export type AggFn =
+  | 'count'
+  | 'count_distinct'
+  | 'sum'
+  | 'avg'
+  | 'min'
+  | 'max'
+  | 'stddev'
+  | 'count_true'
+  | 'count_false'
+
+export const AGG_LABELS: Record<AggFn, string> = {
+  count: 'Count',
+  count_distinct: 'Count distinct',
+  sum: 'Sum',
+  avg: 'Avg',
+  min: 'Min',
+  max: 'Max',
+  stddev: 'Std dev',
+  count_true: 'Count true',
+  count_false: 'Count false',
+}
+
+const NUMERIC = /(int|numeric|decimal|real|double|serial|money)/
+
+/** Functions offered for a column, mirroring the server's type gating. */
+export function aggsForType(dataType: string | undefined): AggFn[] {
+  const t = (dataType ?? '').toLowerCase()
+  if (t.includes('bool')) return ['count', 'count_distinct', 'count_true', 'count_false']
+  if (NUMERIC.test(t)) return ['count', 'count_distinct', 'sum', 'avg', 'min', 'max', 'stddev']
+  return ['count', 'count_distinct', 'min', 'max']
+}
+
+/** SQL expression for one aggregate, used by the Show SQL preview only. */
+export function aggExprSql(fn: AggFn, column: string): string {
+  const col = `"${column}"`
+  switch (fn) {
+    case 'count': return `COUNT(${col})`
+    case 'count_distinct': return `COUNT(DISTINCT ${col})`
+    case 'sum': return `SUM(${col})`
+    case 'avg': return `AVG(${col})`
+    case 'min': return `MIN(${col})`
+    case 'max': return `MAX(${col})`
+    case 'stddev': return `STDDEV(${col})`
+    case 'count_true': return `COUNT(*) FILTER (WHERE ${col} IS TRUE)`
+    case 'count_false': return `COUNT(*) FILTER (WHERE ${col} IS FALSE)`
+  }
+}
+
+/** Read-only preview of the aggregate query for the active columns + filter. */
+export function previewAggregate(
+  tableName: string,
+  aggs: Array<{ column: string; fn: AggFn }>,
+  filter: FilterGroup,
+): string {
+  if (aggs.length === 0) return ''
+  const select = aggs
+    .map((a) => `${aggExprSql(a.fn, a.column)} AS ${a.fn}_${a.column}`)
+    .join(',\n       ')
+  const where = previewWhere(filter)
+  return `SELECT ${select}\n  FROM "${tableName}"${where ? `\n ${where}` : ''}`
+}
+
+/** Format an aggregate value for display. Numerics get thousands separators. */
+export function formatAggValue(value: unknown): string {
+  if (value === null || value === undefined) return '—'
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  const n = typeof value === 'number' ? value : Number(value)
+  if (typeof value !== 'object' && value !== '' && Number.isFinite(n)) {
+    return n.toLocaleString(undefined, { maximumFractionDigits: 4 })
+  }
+  return String(value)
+}

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -350,11 +350,15 @@ export interface FilterGroup {
   children: Array<FilterCondition | FilterGroup>
 }
 
+export interface SortEntry {
+  column: string
+  direction: 'asc' | 'desc'
+}
+
 export interface TableQueryParams {
   page?: number
   limit?: number
-  sortColumn?: string | null
-  sortDirection?: 'asc' | 'desc'
+  sort?: SortEntry[] | null
   filter?: FilterGroup | null
 }
 
@@ -395,9 +399,8 @@ export function getTableData(
   const qs = new URLSearchParams()
   if (params.page) qs.set('page', String(params.page))
   if (params.limit) qs.set('limit', String(params.limit))
-  if (params.sortColumn) {
-    qs.set('sortColumn', params.sortColumn)
-    qs.set('sortDirection', params.sortDirection ?? 'asc')
+  if (params.sort && params.sort.length > 0) {
+    qs.set('sort', JSON.stringify(params.sort))
   }
   if (params.filter && params.filter.children.length > 0) {
     qs.set('filter', JSON.stringify(params.filter))

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -331,11 +331,31 @@ const TableDataResponse = z.object({
 })
 export type TableData = z.infer<typeof TableDataResponse>
 
+export type FilterOp =
+  | 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte'
+  | 'like' | 'ilike' | 'in' | 'nin'
+  | 'is_null' | 'is_not_null'
+  | 'jsonb_contains' | 'array_overlaps'
+
+export interface FilterCondition {
+  type: 'condition'
+  column: string
+  op: FilterOp
+  value?: unknown
+}
+
+export interface FilterGroup {
+  type: 'group'
+  combinator: 'and' | 'or'
+  children: Array<FilterCondition | FilterGroup>
+}
+
 export interface TableQueryParams {
   page?: number
   limit?: number
   sortColumn?: string | null
   sortDirection?: 'asc' | 'desc'
+  filter?: FilterGroup | null
 }
 
 const SchemaColumnSchema = z.object({
@@ -378,6 +398,9 @@ export function getTableData(
   if (params.sortColumn) {
     qs.set('sortColumn', params.sortColumn)
     qs.set('sortDirection', params.sortDirection ?? 'asc')
+  }
+  if (params.filter && params.filter.children.length > 0) {
+    qs.set('filter', JSON.stringify(params.filter))
   }
   const query = qs.toString()
   return api(

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -300,6 +300,92 @@ function triggerDownload(blob: Blob, fileName: string) {
   URL.revokeObjectURL(url)
 }
 
+export type ExportFormat = 'csv' | 'json' | 'sql'
+
+const EXPORT_EXTENSION: Record<ExportFormat, string> = {
+  csv: 'csv',
+  json: 'json',
+  sql: 'sql',
+}
+
+export interface ExportProgress {
+  bytes: number
+}
+
+export interface ExportTableOptions {
+  filter?: FilterGroup | null
+  sort?: SortEntry[] | null
+  /** Subset of columns to include, in order. Omit/empty ⇒ all columns. */
+  columns?: string[] | null
+  limit?: number
+}
+
+/**
+ * Stream a single table's rows to disk in the chosen format, respecting the
+ * supplied filter, sort, and column subset. The body is read incrementally so
+ * the browser never has to hold the whole table at once for large exports.
+ */
+export async function exportTableData(
+  connectionId: string,
+  tableName: string,
+  format: ExportFormat,
+  options: ExportTableOptions = {},
+  onProgress?: (p: ExportProgress) => void,
+  signal?: AbortSignal,
+): Promise<ExportProgress> {
+  const qs = new URLSearchParams()
+  qs.set('format', format)
+  if (options.filter && options.filter.children.length > 0) {
+    qs.set('filter', JSON.stringify(options.filter))
+  }
+  if (options.sort && options.sort.length > 0) {
+    qs.set('sort', JSON.stringify(options.sort))
+  }
+  if (options.columns && options.columns.length > 0) {
+    qs.set('columns', JSON.stringify(options.columns))
+  }
+  if (options.limit) qs.set('limit', String(options.limit))
+
+  const res = await fetch(
+    `/api/tables/${encodeURIComponent(tableName)}/export?${qs.toString()}`,
+    {
+      headers: { 'x-connection-id': connectionId },
+      credentials: 'same-origin',
+      signal,
+    },
+  )
+  if (!res.ok) {
+    const json = await res.json().catch(() => null)
+    throw parseErrorBody(json, res.status)
+  }
+
+  const fileName = `${tableName}.${EXPORT_EXTENSION[format]}`
+  const contentType = res.headers.get('Content-Type') ?? 'application/octet-stream'
+
+  if (!res.body) {
+    // Fallback for environments without ReadableStream.
+    const blob = await res.blob()
+    triggerDownload(blob, fileName)
+    onProgress?.({ bytes: blob.size })
+    return { bytes: blob.size }
+  }
+
+  const reader = res.body.getReader()
+  const chunks: BlobPart[] = []
+  let bytes = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    bytes += value.byteLength
+    onProgress?.({ bytes })
+  }
+
+  triggerDownload(new Blob(chunks, { type: contentType }), fileName)
+  onProgress?.({ bytes })
+  return { bytes }
+}
+
 export function listSchemas(connectionId: string, signal?: AbortSignal) {
   return api('/api/schemas', SchemasResponse, { connectionId, signal })
 }

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -655,6 +655,57 @@ export async function insertRow(
   return InsertRowResponse.parse(json).row
 }
 
+// ---- CSV import -------------------------------------------------------------
+
+export type ImportMode = 'insert' | 'skip' | 'update'
+
+export interface ImportPayload {
+  /** Target columns, in order. */
+  columns: string[]
+  /** Each row's cells, aligned to `columns`. */
+  rows: unknown[][]
+  mode: ImportMode
+  /** ON CONFLICT key columns — required when `mode` is 'update'. */
+  conflictColumns?: string[]
+  /** Blank cell → NULL. Default true server-side. */
+  emptyAsNull?: boolean
+  /** Count only, then roll back. */
+  dryRun?: boolean
+}
+
+const ImportResultResponse = z.object({
+  dryRun: z.boolean(),
+  mode: z.enum(['insert', 'skip', 'update']),
+  attempted: z.number(),
+  inserted: z.number(),
+  updated: z.number(),
+  conflicts: z.number(),
+  batches: z.number().optional(),
+})
+export type ImportResult = z.infer<typeof ImportResultResponse>
+
+export async function importTableData(
+  connectionId: string,
+  tableName: string,
+  payload: ImportPayload,
+): Promise<ImportResult> {
+  const res = await fetch(
+    `/api/tables/${encodeURIComponent(tableName)}/import`,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-connection-id': connectionId,
+      },
+      body: JSON.stringify(payload),
+      credentials: 'same-origin',
+    },
+  )
+  const json = await res.json().catch(() => null)
+  if (!res.ok) throw parseErrorBody(json, res.status)
+  return ImportResultResponse.parse(json)
+}
+
 export function getTableData(
   connectionId: string,
   tableName: string,

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -310,6 +310,11 @@ export function listTables(connectionId: string, signal?: AbortSignal) {
 
 const ColumnMetaSchema = z.object({
   dataType: z.string(),
+  // Real Postgres type name (e.g. `int4`, `_text`, enum name). Older
+  // servers without this field still parse via `.optional()`.
+  udtName: z.string().optional(),
+  isNullable: z.boolean().optional(),
+  hasDefault: z.boolean().optional(),
   isPrimaryKey: z.boolean(),
   isForeignKey: z.boolean(),
   foreignKeyRef: z
@@ -492,6 +497,39 @@ export async function deleteView(id: string): Promise<void> {
     const json = await res.json().catch(() => null)
     throw parseErrorBody(json, res.status)
   }
+}
+
+// ---- Inline row edit --------------------------------------------------------
+
+const UpdateRowResponse = z.object({
+  row: z.record(z.string(), z.unknown()),
+})
+
+export interface UpdateRowPayload {
+  where: Record<string, unknown>
+  set: Record<string, unknown>
+}
+
+export async function updateRow(
+  connectionId: string,
+  tableName: string,
+  payload: UpdateRowPayload,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(
+    `/api/tables/${encodeURIComponent(tableName)}/rows`,
+    {
+      method: 'PATCH',
+      headers: {
+        'content-type': 'application/json',
+        'x-connection-id': connectionId,
+      },
+      body: JSON.stringify(payload),
+      credentials: 'same-origin',
+    },
+  )
+  const json = await res.json().catch(() => null)
+  if (!res.ok) throw parseErrorBody(json, res.status)
+  return UpdateRowResponse.parse(json).row
 }
 
 export function getTableData(

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -591,3 +591,41 @@ export function getTableData(
     { connectionId, signal },
   )
 }
+
+// ---- Per-column aggregations ------------------------------------------------
+
+// `fn` is one of the AggFn values in lib/aggSql; kept as a string here to avoid
+// a circular import (aggSql depends on this module for FilterGroup).
+export interface AggItem {
+  column: string
+  fn: string
+}
+
+const AggregateResponse = z.object({
+  results: z.array(
+    z.object({
+      column: z.string(),
+      fn: z.string(),
+      value: z.unknown(),
+    }),
+  ),
+})
+export type AggregateResult = z.infer<typeof AggregateResponse>
+
+export function getAggregates(
+  connectionId: string,
+  tableName: string,
+  params: { filter?: FilterGroup | null; aggs: AggItem[] },
+  signal?: AbortSignal,
+) {
+  const qs = new URLSearchParams()
+  if (params.filter && params.filter.children.length > 0) {
+    qs.set('filter', JSON.stringify(params.filter))
+  }
+  qs.set('aggs', JSON.stringify(params.aggs))
+  return api(
+    `/api/tables/${encodeURIComponent(tableName)}/aggregate?${qs.toString()}`,
+    AggregateResponse,
+    { connectionId, signal },
+  )
+}

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -390,6 +390,110 @@ export function getDatabaseSchema(connectionId: string, signal?: AbortSignal) {
   return api('/api/schema', SchemaResponse, { connectionId, signal })
 }
 
+// ---- Saved views ------------------------------------------------------------
+
+const FilterConditionApi = z.object({
+  type: z.literal('condition'),
+  column: z.string(),
+  op: z.string(),
+  value: z.unknown().optional(),
+})
+type FilterGroupApi = {
+  type: 'group'
+  combinator: 'and' | 'or'
+  children: Array<z.infer<typeof FilterConditionApi> | FilterGroupApi>
+}
+const FilterGroupApiSchema: z.ZodType<FilterGroupApi> = z.lazy(() =>
+  z.object({
+    type: z.literal('group'),
+    combinator: z.enum(['and', 'or']),
+    children: z.array(z.union([FilterConditionApi, FilterGroupApiSchema])),
+  }),
+)
+
+const SortEntryApi = z.object({
+  column: z.string(),
+  direction: z.enum(['asc', 'desc', 'ASC', 'DESC']),
+})
+
+const SavedViewSchema = z.object({
+  id: z.string(),
+  connectionId: z.string(),
+  tableName: z.string(),
+  name: z.string(),
+  filter: FilterGroupApiSchema.nullable().optional(),
+  sort: z.array(SortEntryApi).optional(),
+  visibleColumns: z.array(z.string()).nullable().optional(),
+  columnWidths: z.record(z.string(), z.number()).nullable().optional(),
+  timezone: z.string().nullable().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+export type SavedView = z.infer<typeof SavedViewSchema>
+
+const ListViewsResponse = z.object({ views: z.array(SavedViewSchema) })
+const ViewEnvelope = z.object({ view: SavedViewSchema })
+
+export interface SaveViewPayload {
+  connectionId: string
+  tableName: string
+  name: string
+  filter?: FilterGroup | null
+  sort?: SortEntry[]
+  visibleColumns?: string[] | null
+  columnWidths?: Record<string, number> | null
+  timezone?: string | null
+}
+
+export function listViews(
+  params: { connectionId?: string; tableName?: string } = {},
+  signal?: AbortSignal,
+) {
+  const qs = new URLSearchParams()
+  if (params.connectionId) qs.set('connectionId', params.connectionId)
+  if (params.tableName) qs.set('tableName', params.tableName)
+  const q = qs.toString()
+  return api(`/api/views${q ? '?' + q : ''}`, ListViewsResponse, { signal })
+}
+
+export async function createView(payload: SaveViewPayload): Promise<SavedView> {
+  const res = await fetch('/api/views', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+    credentials: 'same-origin',
+  })
+  const json = await res.json().catch(() => null)
+  if (!res.ok) throw parseErrorBody(json, res.status)
+  return ViewEnvelope.parse(json).view
+}
+
+export async function updateView(
+  id: string,
+  patch: Partial<SaveViewPayload>,
+): Promise<SavedView> {
+  const res = await fetch(`/api/views/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+    credentials: 'same-origin',
+  })
+  const json = await res.json().catch(() => null)
+  if (!res.ok) throw parseErrorBody(json, res.status)
+  return ViewEnvelope.parse(json).view
+}
+
+export async function deleteView(id: string): Promise<void> {
+  const res = await fetch(`/api/views/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    credentials: 'same-origin',
+  })
+  if (!res.ok) {
+    const json = await res.json().catch(() => null)
+    throw parseErrorBody(json, res.status)
+  }
+}
+
 export function getTableData(
   connectionId: string,
   tableName: string,

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -315,6 +315,9 @@ const ColumnMetaSchema = z.object({
   udtName: z.string().optional(),
   isNullable: z.boolean().optional(),
   hasDefault: z.boolean().optional(),
+  // Raw default expression, surfaced so the insert form can ghost it. Older
+  // servers without the field still parse via `.nullish()`.
+  defaultValue: z.string().nullish(),
   isPrimaryKey: z.boolean(),
   isForeignKey: z.boolean(),
   foreignKeyRef: z
@@ -530,6 +533,40 @@ export async function updateRow(
   const json = await res.json().catch(() => null)
   if (!res.ok) throw parseErrorBody(json, res.status)
   return UpdateRowResponse.parse(json).row
+}
+
+// ---- Row insert -------------------------------------------------------------
+
+const InsertRowResponse = z.object({
+  row: z.record(z.string(), z.unknown()),
+})
+
+export interface InsertRowPayload {
+  // Only the columns the user filled. Omitted columns take their DEFAULT;
+  // an explicit `null` maps to SQL NULL.
+  values: Record<string, unknown>
+}
+
+export async function insertRow(
+  connectionId: string,
+  tableName: string,
+  payload: InsertRowPayload,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(
+    `/api/tables/${encodeURIComponent(tableName)}/rows`,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-connection-id': connectionId,
+      },
+      body: JSON.stringify(payload),
+      credentials: 'same-origin',
+    },
+  )
+  const json = await res.json().catch(() => null)
+  if (!res.ok) throw parseErrorBody(json, res.status)
+  return InsertRowResponse.parse(json).row
 }
 
 export function getTableData(

--- a/client-next/src/lib/csv.ts
+++ b/client-next/src/lib/csv.ts
@@ -1,0 +1,126 @@
+/**
+ * Minimal RFC 4180 CSV parser for the import wizard.
+ *
+ * Parses in the browser so the mapping step can show headers and a sample
+ * without a server round-trip. Handles quoted fields (embedded commas, quotes
+ * doubled as `""`, and newlines), CRLF or LF line endings, and a trailing
+ * newline. The delimiter is configurable (comma default) for TSV pastes.
+ *
+ * It is deliberately not a streaming parser — import sizes are interactive
+ * (the route caps the request), so a single in-memory pass is fine.
+ */
+
+export interface ParsedCsv {
+  /** First row, treated as the header. Empty array if the file is empty. */
+  headers: string[]
+  /** Every subsequent row, each padded/truncated to `headers.length`. */
+  rows: string[][]
+}
+
+/** Parse CSV text into a flat array of records (no header handling). */
+function parseRecords(text: string, delimiter: string): string[][] {
+  const records: string[][] = []
+  let field = ''
+  let record: string[] = []
+  let inQuotes = false
+  let i = 0
+  const n = text.length
+
+  // Strip a leading UTF-8 BOM so the first header isn't prefixed with ﻿.
+  if (text.charCodeAt(0) === 0xfeff) i = 1
+
+  const pushField = () => {
+    record.push(field)
+    field = ''
+  }
+  const pushRecord = () => {
+    pushField()
+    records.push(record)
+    record = []
+  }
+
+  while (i < n) {
+    const ch = text[i]
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"'
+          i += 2
+          continue
+        }
+        inQuotes = false
+        i += 1
+        continue
+      }
+      field += ch
+      i += 1
+      continue
+    }
+    if (ch === '"') {
+      inQuotes = true
+      i += 1
+      continue
+    }
+    if (ch === delimiter) {
+      pushField()
+      i += 1
+      continue
+    }
+    if (ch === '\n') {
+      pushRecord()
+      i += 1
+      continue
+    }
+    if (ch === '\r') {
+      // Treat CRLF and a lone CR as one line break.
+      pushRecord()
+      if (text[i + 1] === '\n') i += 2
+      else i += 1
+      continue
+    }
+    field += ch
+    i += 1
+  }
+
+  // Flush the final record unless the file ended on a clean newline (which
+  // would otherwise yield a spurious empty trailing record).
+  if (field !== '' || record.length > 0) pushRecord()
+
+  return records
+}
+
+export interface ParseCsvOptions {
+  delimiter?: string
+  /** When false, a synthetic `column_1…` header is generated and every line is
+   * treated as data. Default true (first line is the header row). */
+  hasHeader?: boolean
+}
+
+export function parseCsv(text: string, options: ParseCsvOptions = {}): ParsedCsv {
+  const { delimiter = ',', hasHeader = true } = options
+  const records = parseRecords(text, delimiter)
+  if (records.length === 0) return { headers: [], rows: [] }
+
+  let headers: string[]
+  let dataRecords: string[][]
+  if (hasHeader) {
+    headers = records[0]
+    dataRecords = records.slice(1)
+  } else {
+    const width = records.reduce((m, r) => Math.max(m, r.length), 0)
+    headers = Array.from({ length: width }, (_, i) => `column_${i + 1}`)
+    dataRecords = records
+  }
+
+  const width = headers.length
+  const rows = dataRecords.map((r) => {
+    if (r.length === width) return r
+    // Normalize ragged rows so downstream mapping stays aligned: pad short
+    // rows with '' and drop overflow cells.
+    const out = r.slice(0, width)
+    while (out.length < width) out.push('')
+    return out
+  })
+
+  return { headers, rows }
+}

--- a/client-next/src/lib/filterSql.ts
+++ b/client-next/src/lib/filterSql.ts
@@ -1,0 +1,108 @@
+import type { FilterCondition, FilterGroup, FilterOp } from '@/lib/api'
+
+/**
+ * Render a filter spec as a human-readable WHERE clause for the "Show SQL"
+ * disclosure. This mirrors src/db/filter.js but inlines values for display
+ * only — the server uses parameter binding, never string interpolation.
+ */
+export function previewWhere(filter: FilterGroup | null): string {
+  if (!filter || filter.children.length === 0) return ''
+  const inner = renderNode(filter)
+  return inner ? `WHERE ${inner}` : ''
+}
+
+function renderNode(node: FilterCondition | FilterGroup): string {
+  if (node.type === 'group') {
+    const parts = node.children.map(renderNode).filter(Boolean)
+    if (parts.length === 0) return ''
+    if (parts.length === 1) return parts[0]
+    return `(${parts.join(node.combinator === 'or' ? ' OR ' : ' AND ')})`
+  }
+  return renderCondition(node)
+}
+
+function renderCondition(c: FilterCondition): string {
+  const col = quoteIdent(c.column)
+  switch (c.op) {
+    case 'is_null': return `${col} IS NULL`
+    case 'is_not_null': return `${col} IS NOT NULL`
+    case 'eq':  return `${col} = ${literal(c.value)}`
+    case 'neq': return `${col} <> ${literal(c.value)}`
+    case 'gt':  return `${col} > ${literal(c.value)}`
+    case 'gte': return `${col} >= ${literal(c.value)}`
+    case 'lt':  return `${col} < ${literal(c.value)}`
+    case 'lte': return `${col} <= ${literal(c.value)}`
+    case 'like':  return `${col} LIKE ${literal(c.value)}`
+    case 'ilike': return `${col} ILIKE ${literal(c.value)}`
+    case 'in':  return `${col} IN (${arrayLiteral(c.value)})`
+    case 'nin': return `${col} NOT IN (${arrayLiteral(c.value)})`
+    case 'jsonb_contains': return `${col} @> ${jsonbLiteral(c.value)}`
+    case 'array_overlaps': return `${col} && ARRAY[${arrayLiteral(c.value)}]`
+  }
+}
+
+function quoteIdent(name: string): string {
+  return `"${name.replaceAll('"', '""')}"`
+}
+
+function literal(v: unknown): string {
+  if (v === null || v === undefined) return 'NULL'
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+  return `'${String(v).replaceAll("'", "''")}'`
+}
+
+function arrayLiteral(v: unknown): string {
+  if (!Array.isArray(v)) return ''
+  return v.map(literal).join(', ')
+}
+
+function jsonbLiteral(v: unknown): string {
+  const json = typeof v === 'string' ? v : JSON.stringify(v)
+  return `'${json.replaceAll("'", "''")}'::jsonb`
+}
+
+export const OPERATOR_LABELS: Record<FilterOp, string> = {
+  eq: '=',
+  neq: '≠',
+  gt: '>',
+  gte: '≥',
+  lt: '<',
+  lte: '≤',
+  like: 'LIKE',
+  ilike: 'ILIKE',
+  in: 'IN',
+  nin: 'NOT IN',
+  is_null: 'IS NULL',
+  is_not_null: 'IS NOT NULL',
+  jsonb_contains: '@>',
+  array_overlaps: '&&',
+}
+
+/**
+ * Operators valid for a given Postgres data type. Returned in display order.
+ */
+export function operatorsForType(dataType: string | undefined): FilterOp[] {
+  const t = (dataType ?? '').toLowerCase()
+  const isBool = t === 'boolean' || t === 'bool'
+  const isNumeric = /(^|\s)(smallint|integer|bigint|numeric|decimal|real|double precision|serial|bigserial)/.test(t)
+  const isText = t === 'text' || t.startsWith('character') || t.startsWith('varchar') || t === 'citext'
+  const isDateish = t === 'date' || t.startsWith('timestamp') || t.startsWith('time')
+  const isJson = t === 'json' || t === 'jsonb'
+  const isArray = t.endsWith('[]') || t.startsWith('_')
+
+  const base: FilterOp[] = ['eq', 'neq', 'is_null', 'is_not_null']
+  if (isBool) return ['eq', 'neq', 'is_null', 'is_not_null']
+  if (isNumeric || isDateish) return ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'nin', 'is_null', 'is_not_null']
+  if (isText) return ['eq', 'neq', 'like', 'ilike', 'in', 'nin', 'is_null', 'is_not_null']
+  if (isJson) return ['jsonb_contains', 'is_null', 'is_not_null']
+  if (isArray) return ['array_overlaps', 'is_null', 'is_not_null']
+  return [...base, 'gt', 'gte', 'lt', 'lte', 'in', 'nin']
+}
+
+export function opNeedsValue(op: FilterOp): boolean {
+  return op !== 'is_null' && op !== 'is_not_null'
+}
+
+export function opTakesArray(op: FilterOp): boolean {
+  return op === 'in' || op === 'nin' || op === 'array_overlaps'
+}

--- a/client-next/src/lib/insertSql.ts
+++ b/client-next/src/lib/insertSql.ts
@@ -1,0 +1,38 @@
+import type { ColumnMeta } from '@/lib/api'
+
+/**
+ * Render an insert spec as a human-readable INSERT for the "Show SQL"
+ * disclosure. Mirrors src/db/insert.js but inlines values for display only —
+ * the server uses parameter binding, never string interpolation.
+ *
+ * Only columns present in `values` appear; omitted columns take their DEFAULT
+ * server-side, so an empty object renders `DEFAULT VALUES`.
+ */
+export function previewInsert(
+  tableName: string,
+  values: Record<string, unknown>,
+  columns: Record<string, ColumnMeta>,
+): string {
+  const keys = Object.keys(values)
+  if (keys.length === 0) {
+    return `INSERT INTO ${quoteIdent(tableName)} DEFAULT VALUES`
+  }
+  const cols = keys.map(quoteIdent).join(', ')
+  const vals = keys.map((k) => literal(values[k], columns[k])).join(', ')
+  return `INSERT INTO ${quoteIdent(tableName)} (${cols})\nVALUES (${vals})`
+}
+
+function quoteIdent(name: string): string {
+  return `"${name.replaceAll('"', '""')}"`
+}
+
+function literal(v: unknown, meta: ColumnMeta | undefined): string {
+  if (v === null || v === undefined) return 'NULL'
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+  const t = (meta?.dataType ?? '').toLowerCase()
+  if (t === 'json' || t === 'jsonb') {
+    const json = typeof v === 'string' ? v : JSON.stringify(v)
+    return `'${json.replaceAll("'", "''")}'::${t}`
+  }
+  return `'${String(v).replaceAll("'", "''")}'`
+}

--- a/client-next/src/pages/QueryRunner.tsx
+++ b/client-next/src/pages/QueryRunner.tsx
@@ -125,7 +125,7 @@ export function QueryRunner() {
               <DataGrid
                 rows={mutation.data.rows}
                 columns={columns}
-                sort={null}
+                sort={[]}
                 onSortChange={() => {}}
               />
             ) : (

--- a/client-next/src/pages/TableView.tsx
+++ b/client-next/src/pages/TableView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 
 import { Loading, Spinner } from "@/components/ui/spinner";
 
@@ -11,6 +11,7 @@ import { DataGrid, type SortState } from "@/components/DataGrid";
 import { EMPTY_FILTER, FilterBar } from "@/components/FilterBar";
 import { SortBar } from "@/components/SortBar";
 import { ViewBar } from "@/components/ViewBar";
+import { InsertRowDialog } from "@/components/InsertRowDialog";
 import {
   getTableData, listViews, updateRow,
   type FilterGroup, type SavedView, type TableData,
@@ -68,6 +69,7 @@ export function TableView() {
   const [limit, setLimit] = useState<number>(100);
   const [sort, setSort] = useState<SortState>([]);
   const [filter, setFilter] = useState<FilterGroup>(EMPTY_FILTER);
+  const [insertOpen, setInsertOpen] = useState(false);
 
   // Selected saved view id. `null` means the synthetic "All rows" default.
   // The URL is the source of truth so the picker is deep-linkable.
@@ -197,6 +199,11 @@ export function TableView() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          {data?.columns && (
+            <Button size="sm" onClick={() => setInsertOpen(true)}>
+              <Plus className="h-4 w-4" /> Insert row
+            </Button>
+          )}
           <Select
             value={String(limit)}
             onChange={(e) => {
@@ -353,6 +360,23 @@ export function TableView() {
           </Loading>
         )}
       </div>
+
+      {data?.columns && (
+        <InsertRowDialog
+          open={insertOpen}
+          onClose={() => setInsertOpen(false)}
+          connectionId={connectionId}
+          tableName={tableName}
+          columns={data.columns}
+          onInserted={() => {
+            // Refetch every page/sort/filter variant of this table so the new
+            // row appears wherever the user lands.
+            qc.invalidateQueries({
+              queryKey: ["table", connectionId, tableName],
+            });
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/client-next/src/pages/TableView.tsx
+++ b/client-next/src/pages/TableView.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -8,11 +8,32 @@ import { Loading, Spinner } from "@/components/ui/spinner";
 import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
 import { DataGrid, type SortState } from "@/components/DataGrid";
-import { getTableData } from "@/lib/api";
+import { EMPTY_FILTER, FilterBar } from "@/components/FilterBar";
+import { getTableData, type FilterGroup } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
 
 const PAGE_SIZES = [50, 100, 250, 500] as const;
+
+/**
+ * Strip conditions whose value isn't ready yet (newly-added rows with empty
+ * input) so the server isn't asked to filter on an empty string against a
+ * non-text column. Valueless ops (`IS NULL`/`IS NOT NULL`) and array ops
+ * with a populated array stay in.
+ */
+function pruneIncomplete(filter: FilterGroup): FilterGroup {
+  return {
+    ...filter,
+    children: filter.children.filter((c) => {
+      if (c.type !== "condition") return true;
+      if (c.op === "is_null" || c.op === "is_not_null") return true;
+      if (c.op === "in" || c.op === "nin" || c.op === "array_overlaps") {
+        return Array.isArray(c.value) && c.value.length > 0;
+      }
+      return c.value !== "" && c.value != null;
+    }),
+  };
+}
 
 export function TableView() {
   const { tableName } = useParams({ from: "/tables/$tableName" });
@@ -21,9 +42,23 @@ export function TableView() {
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState<number>(100);
   const [sort, setSort] = useState<SortState>(null);
+  const [filter, setFilter] = useState<FilterGroup>(EMPTY_FILTER);
+
+  // Switching tables: drop filter + sort + page, since column names referenced
+  // by the prior table's filter won't exist on the new one.
+  useEffect(() => {
+    setFilter(EMPTY_FILTER);
+    setSort(null);
+    setPage(1);
+  }, [tableName]);
+
+  // Incomplete conditions (newly-added rows with empty values) would 400 the
+  // server, so prune them from the version sent — the UI keeps the row open
+  // for editing.
+  const appliedFilter = pruneIncomplete(filter);
 
   const query = useQuery({
-    queryKey: ["table", connectionId, tableName, page, limit, sort],
+    queryKey: ["table", connectionId, tableName, page, limit, sort, appliedFilter],
     queryFn: ({ signal }) =>
       getTableData(
         connectionId!,
@@ -33,6 +68,7 @@ export function TableView() {
           limit,
           sortColumn: sort?.column ?? null,
           sortDirection: sort?.direction,
+          filter: appliedFilter,
         },
         signal,
       ),
@@ -121,6 +157,17 @@ export function TableView() {
           </Button>
         </div>
       </header>
+
+      {data?.columns && (
+        <FilterBar
+          columns={data.columns}
+          filter={filter}
+          onChange={(next) => {
+            setPage(1);
+            setFilter(next);
+          }}
+        />
+      )}
 
       <div className="min-h-0 flex-1 p-4">
         {query.error && (

--- a/client-next/src/pages/TableView.tsx
+++ b/client-next/src/pages/TableView.tsx
@@ -12,9 +12,10 @@ import { EMPTY_FILTER, FilterBar } from "@/components/FilterBar";
 import { SortBar } from "@/components/SortBar";
 import { ViewBar } from "@/components/ViewBar";
 import { InsertRowDialog } from "@/components/InsertRowDialog";
+import { FkPanel, type FkTarget } from "@/components/FkPanel";
 import {
   getTableData, listViews, updateRow,
-  type FilterGroup, type SavedView, type TableData,
+  type ColumnMeta, type FilterGroup, type SavedView, type TableData,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
@@ -39,6 +40,21 @@ function pruneIncomplete(filter: FilterGroup): FilterGroup {
       return c.value !== "" && c.value != null;
     }),
   };
+}
+
+/**
+ * Coerce an FK value that crossed the URL as a string back to the JS type the
+ * referenced column expects, so the equality filter binds correctly (an int
+ * column needs `42`, not `"42"`).
+ */
+function coerceFkValue(raw: string, meta: ColumnMeta | undefined): unknown {
+  const t = (meta?.dataType ?? "").toLowerCase();
+  if (/(int|numeric|decimal|real|double|serial)/.test(t)) {
+    const n = Number(raw);
+    return Number.isNaN(n) ? raw : n;
+  }
+  if (t === "boolean" || t === "bool") return raw === "true";
+  return raw;
 }
 
 /** Materialize a saved view into the working filter/sort the table renders. */
@@ -70,6 +86,8 @@ export function TableView() {
   const [sort, setSort] = useState<SortState>([]);
   const [filter, setFilter] = useState<FilterGroup>(EMPTY_FILTER);
   const [insertOpen, setInsertOpen] = useState(false);
+  // The FK cell the user clicked → drives the referenced-row side panel.
+  const [fkTarget, setFkTarget] = useState<FkTarget | null>(null);
 
   // Selected saved view id. `null` means the synthetic "All rows" default.
   // The URL is the source of truth so the picker is deep-linkable.
@@ -156,6 +174,45 @@ export function TableView() {
       return undefined;
     },
   });
+
+  // FK click-through landing: `?fkcol&fkval` arrives from the panel's "show
+  // all rows that reference this row" jump. Apply it as a single equality
+  // filter once column metadata is loaded (so the value can be type-coerced),
+  // then strip the params — the user owns the filter from there.
+  const lastFkApplied = useRef<string | null>(null);
+  useEffect(() => {
+    const { fkcol, fkval } = search;
+    if (fkcol == null || fkval == null) {
+      lastFkApplied.current = null;
+      return;
+    }
+    const cols = query.data?.columns;
+    if (!cols) return; // wait for metadata so we can type-coerce the value
+    const key = `${tableName}|${fkcol}=${fkval}`;
+    if (lastFkApplied.current === key) return;
+    lastFkApplied.current = key;
+
+    if (cols[fkcol]) {
+      setPage(1);
+      setFilter({
+        type: "group",
+        combinator: "and",
+        children: [
+          {
+            type: "condition",
+            column: fkcol,
+            op: "eq",
+            value: coerceFkValue(fkval, cols[fkcol]),
+          },
+        ],
+      });
+    }
+    navigate({
+      search: (prev: { view?: string }) =>
+        prev.view ? { view: prev.view } : {},
+      replace: true,
+    });
+  }, [search, tableName, query.data, navigate]);
 
   if (!connectionId) {
     return (
@@ -294,6 +351,18 @@ export function TableView() {
                 setPage(1);
                 setSort(s);
               }}
+              onOpenFk={(column, value) => {
+                const meta = data.columns[column];
+                if (!meta?.foreignKeyRef || value == null) return;
+                setFkTarget({
+                  refTable: meta.foreignKeyRef.table,
+                  refColumn: meta.foreignKeyRef.column,
+                  refValue: value,
+                  originTable: tableName,
+                  originColumn: column,
+                  originValue: value,
+                });
+              }}
               editable={data.hasPrimaryKey}
               onCommitCell={async (rowIndex, column, newValue) => {
                 const queryKey = [
@@ -373,6 +442,24 @@ export function TableView() {
             // row appears wherever the user lands.
             qc.invalidateQueries({
               queryKey: ["table", connectionId, tableName],
+            });
+          }}
+        />
+      )}
+
+      {fkTarget && (
+        <FkPanel
+          // Remount on a new FK click so the click-through chain resets.
+          key={`${fkTarget.refTable}:${fkTarget.refColumn}:${String(fkTarget.refValue)}`}
+          connectionId={connectionId}
+          target={fkTarget}
+          onClose={() => setFkTarget(null)}
+          onShowReferencing={(table, column, value) => {
+            setFkTarget(null);
+            navigate({
+              to: "/tables/$tableName",
+              params: { tableName: table },
+              search: { fkcol: column, fkval: String(value) },
             });
           }}
         />

--- a/client-next/src/pages/TableView.tsx
+++ b/client-next/src/pages/TableView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus, Upload } from "lucide-react";
 
 import { Loading, Spinner } from "@/components/ui/spinner";
 
@@ -12,6 +12,7 @@ import { EMPTY_FILTER, FilterBar } from "@/components/FilterBar";
 import { SortBar } from "@/components/SortBar";
 import { ViewBar } from "@/components/ViewBar";
 import { InsertRowDialog } from "@/components/InsertRowDialog";
+import { ImportDialog } from "@/components/ImportDialog";
 import { ExportMenu } from "@/components/ExportMenu";
 import { FkPanel, type FkTarget } from "@/components/FkPanel";
 import {
@@ -91,6 +92,7 @@ export function TableView() {
   // per-column footer in the grid.
   const [aggregations, setAggregations] = useState<Record<string, AggFn>>({});
   const [insertOpen, setInsertOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
   // The FK cell the user clicked → drives the referenced-row side panel.
   const [fkTarget, setFkTarget] = useState<FkTarget | null>(null);
 
@@ -299,6 +301,9 @@ export function TableView() {
               <Button size="sm" onClick={() => setInsertOpen(true)}>
                 <Plus className="h-4 w-4" /> Insert row
               </Button>
+              <Button size="sm" variant="outline" onClick={() => setImportOpen(true)}>
+                <Upload className="h-4 w-4" /> Import
+              </Button>
               <ExportMenu
                 connectionId={connectionId}
                 tableName={tableName}
@@ -500,6 +505,21 @@ export function TableView() {
           onInserted={() => {
             // Refetch every page/sort/filter variant of this table so the new
             // row appears wherever the user lands.
+            qc.invalidateQueries({
+              queryKey: ["table", connectionId, tableName],
+            });
+          }}
+        />
+      )}
+
+      {data?.columns && (
+        <ImportDialog
+          open={importOpen}
+          onClose={() => setImportOpen(false)}
+          connectionId={connectionId}
+          tableName={tableName}
+          columns={data.columns}
+          onImported={() => {
             qc.invalidateQueries({
               queryKey: ["table", connectionId, tableName],
             });

--- a/client-next/src/pages/TableView.tsx
+++ b/client-next/src/pages/TableView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
@@ -14,9 +14,10 @@ import { ViewBar } from "@/components/ViewBar";
 import { InsertRowDialog } from "@/components/InsertRowDialog";
 import { FkPanel, type FkTarget } from "@/components/FkPanel";
 import {
-  getTableData, listViews, updateRow,
+  getAggregates, getTableData, listViews, updateRow,
   type ColumnMeta, type FilterGroup, type SavedView, type TableData,
 } from "@/lib/api";
+import { type AggFn, previewAggregate } from "@/lib/aggSql";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
 
@@ -85,6 +86,9 @@ export function TableView() {
   const [limit, setLimit] = useState<number>(100);
   const [sort, setSort] = useState<SortState>([]);
   const [filter, setFilter] = useState<FilterGroup>(EMPTY_FILTER);
+  // Active aggregate function per column (at most one each). Drives the
+  // per-column footer in the grid.
+  const [aggregations, setAggregations] = useState<Record<string, AggFn>>({});
   const [insertOpen, setInsertOpen] = useState(false);
   // The FK cell the user clicked → drives the referenced-row side panel.
   const [fkTarget, setFkTarget] = useState<FkTarget | null>(null);
@@ -100,6 +104,7 @@ export function TableView() {
   useEffect(() => {
     setFilter(EMPTY_FILTER);
     setSort([]);
+    setAggregations({});
     setPage(1);
   }, [tableName]);
 
@@ -174,6 +179,38 @@ export function TableView() {
       return undefined;
     },
   });
+
+  // Aggregations strip: one running aggregate per chosen column, recomputed
+  // server-side against the same filter as the data read.
+  const aggList = useMemo(
+    () => Object.entries(aggregations).map(([column, fn]) => ({ column, fn })),
+    [aggregations],
+  );
+
+  const aggQuery = useQuery({
+    queryKey: ["aggregate", connectionId, tableName, appliedFilter, aggList],
+    queryFn: ({ signal }) =>
+      getAggregates(
+        connectionId!,
+        tableName,
+        { filter: appliedFilter, aggs: aggList },
+        signal,
+      ),
+    enabled: !!connectionId && aggList.length > 0,
+    // Keep prior values on screen while recomputing so the footer doesn't flash.
+    placeholderData: (prev) => prev,
+  });
+
+  const aggValues = useMemo(() => {
+    const map: Record<string, unknown> = {};
+    for (const r of aggQuery.data?.results ?? []) map[r.column] = r.value;
+    return map;
+  }, [aggQuery.data]);
+
+  const aggSqlPreview = useMemo(
+    () => previewAggregate(tableName, aggList, appliedFilter),
+    [tableName, aggList, appliedFilter],
+  );
 
   // FK click-through landing: `?fkcol&fkval` arrives from the panel's "show
   // all rows that reference this row" jump. Apply it as a single equality
@@ -363,6 +400,19 @@ export function TableView() {
                   originValue: value,
                 });
               }}
+              aggregations={aggregations}
+              aggValues={aggValues}
+              aggLoading={aggQuery.isFetching}
+              aggSqlPreview={aggSqlPreview}
+              onAggregationChange={(column, fn) =>
+                setAggregations((prev) => {
+                  if (fn === null) {
+                    const { [column]: _drop, ...rest } = prev;
+                    return rest;
+                  }
+                  return { ...prev, [column]: fn };
+                })
+              }
               editable={data.hasPrimaryKey}
               onCommitCell={async (rowIndex, column, newValue) => {
                 const queryKey = [

--- a/client-next/src/pages/TableView.tsx
+++ b/client-next/src/pages/TableView.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
-import { useParams } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { Loading, Spinner } from "@/components/ui/spinner";
@@ -10,7 +10,10 @@ import { Select } from "@/components/ui/select";
 import { DataGrid, type SortState } from "@/components/DataGrid";
 import { EMPTY_FILTER, FilterBar } from "@/components/FilterBar";
 import { SortBar } from "@/components/SortBar";
-import { getTableData, type FilterGroup } from "@/lib/api";
+import { ViewBar } from "@/components/ViewBar";
+import {
+  getTableData, listViews, type FilterGroup, type SavedView,
+} from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
 
@@ -36,22 +39,91 @@ function pruneIncomplete(filter: FilterGroup): FilterGroup {
   };
 }
 
+/** Materialize a saved view into the working filter/sort the table renders. */
+function snapshotFromView(view: SavedView): {
+  filter: FilterGroup;
+  sort: SortState;
+} {
+  const filter =
+    view.filter && view.filter.children.length > 0
+      ? (view.filter as FilterGroup)
+      : EMPTY_FILTER;
+  const sort: SortState = (view.sort ?? []).map((s) => ({
+    column: s.column,
+    // Persisted views may have upper-case directions; normalize.
+    direction: s.direction.toLowerCase() as "asc" | "desc",
+  }));
+  return { filter, sort };
+}
+
 export function TableView() {
   const { tableName } = useParams({ from: "/tables/$tableName" });
+  const search = useSearch({ from: "/tables/$tableName" });
+  const navigate = useNavigate({ from: "/tables/$tableName" });
   const connectionId = useConnectionStore((s) => s.activeConnectionId);
+  const qc = useQueryClient();
 
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState<number>(100);
   const [sort, setSort] = useState<SortState>([]);
   const [filter, setFilter] = useState<FilterGroup>(EMPTY_FILTER);
 
+  // Selected saved view id. `null` means the synthetic "All rows" default.
+  // The URL is the source of truth so the picker is deep-linkable.
+  const selectedViewId = search.view ?? null;
+
   // Switching tables: drop filter + sort + page, since column names referenced
-  // by the prior table's filter won't exist on the new one.
+  // by the prior table's filter won't exist on the new one. The selected
+  // view id lives in the URL search params, which TanStack Router clears
+  // when the path param changes — but we still reset working state here.
   useEffect(() => {
     setFilter(EMPTY_FILTER);
     setSort([]);
     setPage(1);
   }, [tableName]);
+
+  // Hydrate filter + sort from the selected view. We re-fetch the list to
+  // avoid a separate single-view endpoint; the data is already cached for
+  // the ViewBar so this is free in steady state.
+  const lastHydratedView = useRef<string | null>(null);
+  useEffect(() => {
+    if (!connectionId) return;
+    // Re-hydrate when the URL view id changes (including becoming null).
+    if (lastHydratedView.current === selectedViewId) return;
+    lastHydratedView.current = selectedViewId;
+
+    if (selectedViewId === null) {
+      // "All rows" — reset to a clean slate.
+      setFilter(EMPTY_FILTER);
+      setSort([]);
+      setPage(1);
+      return;
+    }
+
+    let cancelled = false;
+    qc.fetchQuery({
+      queryKey: ['views', connectionId, tableName],
+      queryFn: ({ signal }) =>
+        listViews({ connectionId, tableName }, signal).then((r) => r.views),
+    }).then((vs) => {
+      if (cancelled) return;
+      const view = vs.find((v) => v.id === selectedViewId);
+      if (!view) {
+        // Stale URL — clear the param so we don't re-attempt every render.
+        navigate({ search: {}, replace: true });
+        return;
+      }
+      const snap = snapshotFromView(view);
+      setFilter(snap.filter);
+      setSort(snap.sort);
+      setPage(1);
+    }).catch(() => {
+      // Network failure leaves working state untouched.
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedViewId, connectionId, tableName, qc, navigate]);
 
   // Incomplete conditions (newly-added rows with empty values) would 400 the
   // server, so prune them from the version sent — the UI keeps the row open
@@ -157,6 +229,20 @@ export function TableView() {
           </Button>
         </div>
       </header>
+
+      <ViewBar
+        connectionId={connectionId}
+        tableName={tableName}
+        selectedViewId={selectedViewId}
+        onSelectView={(id) =>
+          navigate({
+            search: id ? { view: id } : {},
+            replace: true,
+          })
+        }
+        filter={filter}
+        sort={sort}
+      />
 
       {data?.columns && (
         <>

--- a/client-next/src/pages/TableView.tsx
+++ b/client-next/src/pages/TableView.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
 import { DataGrid, type SortState } from "@/components/DataGrid";
 import { EMPTY_FILTER, FilterBar } from "@/components/FilterBar";
+import { SortBar } from "@/components/SortBar";
 import { getTableData, type FilterGroup } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
@@ -41,14 +42,14 @@ export function TableView() {
 
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState<number>(100);
-  const [sort, setSort] = useState<SortState>(null);
+  const [sort, setSort] = useState<SortState>([]);
   const [filter, setFilter] = useState<FilterGroup>(EMPTY_FILTER);
 
   // Switching tables: drop filter + sort + page, since column names referenced
   // by the prior table's filter won't exist on the new one.
   useEffect(() => {
     setFilter(EMPTY_FILTER);
-    setSort(null);
+    setSort([]);
     setPage(1);
   }, [tableName]);
 
@@ -66,8 +67,7 @@ export function TableView() {
         {
           page,
           limit,
-          sortColumn: sort?.column ?? null,
-          sortDirection: sort?.direction,
+          sort,
           filter: appliedFilter,
         },
         signal,
@@ -159,14 +159,24 @@ export function TableView() {
       </header>
 
       {data?.columns && (
-        <FilterBar
-          columns={data.columns}
-          filter={filter}
-          onChange={(next) => {
-            setPage(1);
-            setFilter(next);
-          }}
-        />
+        <>
+          <FilterBar
+            columns={data.columns}
+            filter={filter}
+            onChange={(next) => {
+              setPage(1);
+              setFilter(next);
+            }}
+          />
+          <SortBar
+            columns={data.columns}
+            sort={sort}
+            onChange={(next) => {
+              setPage(1);
+              setSort(next);
+            }}
+          />
+        </>
       )}
 
       <div className="min-h-0 flex-1 p-4">

--- a/client-next/src/pages/TableView.tsx
+++ b/client-next/src/pages/TableView.tsx
@@ -12,7 +12,8 @@ import { EMPTY_FILTER, FilterBar } from "@/components/FilterBar";
 import { SortBar } from "@/components/SortBar";
 import { ViewBar } from "@/components/ViewBar";
 import {
-  getTableData, listViews, type FilterGroup, type SavedView,
+  getTableData, listViews, updateRow,
+  type FilterGroup, type SavedView, type TableData,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
@@ -285,6 +286,63 @@ export function TableView() {
               onSortChange={(s) => {
                 setPage(1);
                 setSort(s);
+              }}
+              editable={data.hasPrimaryKey}
+              onCommitCell={async (rowIndex, column, newValue) => {
+                const queryKey = [
+                  "table",
+                  connectionId,
+                  tableName,
+                  page,
+                  limit,
+                  sort,
+                  appliedFilter,
+                ] as const;
+                const snapshot = qc.getQueryData<TableData>(queryKey);
+                const row = snapshot?.rows[rowIndex];
+                if (!snapshot || !row) {
+                  throw new Error("Row no longer in view — reload and retry.");
+                }
+                // Build `where` from all PK columns on the row. The server
+                // re-validates and rejects if any column went missing.
+                const pkCols = Object.entries(snapshot.columns)
+                  .filter(([, m]) => m.isPrimaryKey)
+                  .map(([name]) => name);
+                const where: Record<string, unknown> = {};
+                for (const pk of pkCols) where[pk] = row[pk];
+
+                // Optimistic patch — flip the cell now so the grid clears
+                // the editor without flicker. Roll back on error.
+                qc.setQueryData<TableData>(queryKey, (cur) => {
+                  if (!cur) return cur;
+                  const nextRows = cur.rows.slice();
+                  nextRows[rowIndex] = { ...row, [column]: newValue };
+                  return { ...cur, rows: nextRows };
+                });
+
+                try {
+                  const updated = await updateRow(connectionId!, tableName, {
+                    where,
+                    set: { [column]: newValue },
+                  });
+                  // Server-returned row supersedes the optimistic guess
+                  // (triggers, defaults, type coercion may have altered it).
+                  qc.setQueryData<TableData>(queryKey, (cur) => {
+                    if (!cur) return cur;
+                    const nextRows = cur.rows.slice();
+                    nextRows[rowIndex] = updated;
+                    return { ...cur, rows: nextRows };
+                  });
+                } catch (err) {
+                  // Roll back the optimistic write.
+                  qc.setQueryData<TableData>(queryKey, (cur) => {
+                    if (!cur) return cur;
+                    const nextRows = cur.rows.slice();
+                    nextRows[rowIndex] = row;
+                    return { ...cur, rows: nextRows };
+                  });
+                  throw err;
+                }
               }}
             />
           </div>

--- a/client-next/src/pages/TableView.tsx
+++ b/client-next/src/pages/TableView.tsx
@@ -12,6 +12,7 @@ import { EMPTY_FILTER, FilterBar } from "@/components/FilterBar";
 import { SortBar } from "@/components/SortBar";
 import { ViewBar } from "@/components/ViewBar";
 import { InsertRowDialog } from "@/components/InsertRowDialog";
+import { ExportMenu } from "@/components/ExportMenu";
 import { FkPanel, type FkTarget } from "@/components/FkPanel";
 import {
   getAggregates, getTableData, listViews, updateRow,
@@ -294,9 +295,18 @@ export function TableView() {
         </div>
         <div className="flex items-center gap-2">
           {data?.columns && (
-            <Button size="sm" onClick={() => setInsertOpen(true)}>
-              <Plus className="h-4 w-4" /> Insert row
-            </Button>
+            <>
+              <Button size="sm" onClick={() => setInsertOpen(true)}>
+                <Plus className="h-4 w-4" /> Insert row
+              </Button>
+              <ExportMenu
+                connectionId={connectionId}
+                tableName={tableName}
+                columns={data.columns}
+                filter={appliedFilter}
+                sort={sort}
+              />
+            </>
           )}
           <Select
             value={String(limit)}

--- a/client-next/src/routeTree.tsx
+++ b/client-next/src/routeTree.tsx
@@ -35,11 +35,25 @@ const tableRoute = createRoute({
   path: '/tables/$tableName',
   component: TableView,
   // Deep-linkable saved view: `?view=<uuid>` selects a saved view on load.
+  // FK click-through: `?fkcol=<col>&fkval=<value>` opens the table with a
+  // single equality filter pre-applied (the "show all rows that reference
+  // this row" jump). Both fk params must be present to take effect.
   validateSearch: (
     search: Record<string, unknown>,
-  ): { view?: string } => {
+  ): { view?: string; fkcol?: string; fkval?: string } => {
+    const out: { view?: string; fkcol?: string; fkval?: string } = {}
     const v = search.view
-    return typeof v === 'string' && v.length > 0 ? { view: v } : {}
+    if (typeof v === 'string' && v.length > 0) out.view = v
+    const fkcol = search.fkcol
+    const fkval = search.fkval
+    if (
+      typeof fkcol === 'string' && fkcol.length > 0 &&
+      typeof fkval === 'string'
+    ) {
+      out.fkcol = fkcol
+      out.fkval = fkval
+    }
+    return out
   },
 })
 

--- a/client-next/src/routeTree.tsx
+++ b/client-next/src/routeTree.tsx
@@ -34,6 +34,13 @@ const tableRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/tables/$tableName',
   component: TableView,
+  // Deep-linkable saved view: `?view=<uuid>` selects a saved view on load.
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { view?: string } => {
+    const v = search.view
+    return typeof v === 'string' && v.length > 0 ? { view: v } : {}
+  },
 })
 
 const schemaRoute = createRoute({

--- a/client-next/test/unit/api.test.ts
+++ b/client-next/test/unit/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { ApiError, exportTableData, listConnections, runQuery } from '@/lib/api'
+import { ApiError, exportTableData, importTableData, listConnections, runQuery } from '@/lib/api'
 import type { FilterGroup } from '@/lib/api'
 
 const fetchMock = vi.fn()
@@ -175,6 +175,52 @@ describe('exportTableData', () => {
     )
     await expect(
       exportTableData('conn-1', 'users', 'csv', { columns: ['nope'] }),
+    ).rejects.toBeInstanceOf(ApiError)
+  })
+})
+
+describe('importTableData', () => {
+  it('POSTs the mapping, rows, and mode and parses the result envelope', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        dryRun: true,
+        mode: 'skip',
+        attempted: 3,
+        inserted: 2,
+        updated: 0,
+        conflicts: 1,
+      }),
+    )
+    const result = await importTableData('conn-1', 'users', {
+      columns: ['id', 'name'],
+      rows: [['1', 'Ann'], ['2', 'Bob'], ['3', 'Cy']],
+      mode: 'skip',
+      dryRun: true,
+    })
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/tables/users/import')
+    expect((init as RequestInit).method).toBe('POST')
+    expect(((init as RequestInit).headers as Record<string, string>)['x-connection-id']).toBe('conn-1')
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body.columns).toEqual(['id', 'name'])
+    expect(body.mode).toBe('skip')
+    expect(body.dryRun).toBe(true)
+    expect(result.conflicts).toBe(1)
+  })
+
+  it('throws ApiError when the import is rejected', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        { error: { code: 'DB_ERROR', message: 'duplicate key value violates unique constraint' } },
+        { status: 400 },
+      ),
+    )
+    await expect(
+      importTableData('conn-1', 'users', {
+        columns: ['id'],
+        rows: [['1']],
+        mode: 'insert',
+      }),
     ).rejects.toBeInstanceOf(ApiError)
   })
 })

--- a/client-next/test/unit/api.test.ts
+++ b/client-next/test/unit/api.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { ApiError, listConnections, runQuery } from '@/lib/api'
+import { ApiError, exportTableData, listConnections, runQuery } from '@/lib/api'
+import type { FilterGroup } from '@/lib/api'
 
 const fetchMock = vi.fn()
 vi.stubGlobal('fetch', fetchMock)
@@ -105,5 +106,75 @@ describe('runQuery', () => {
       ),
     )
     await expect(runQuery('conn-1', 'FOO')).rejects.toBeInstanceOf(ApiError)
+  })
+})
+
+describe('exportTableData', () => {
+  // Drive exportTableData down the `!res.body` fallback path so we don't need
+  // to fake a ReadableStream; stub the DOM download primitives jsdom lacks.
+  function downloadResponse(body: unknown) {
+    return {
+      ok: true,
+      status: 200,
+      body: null,
+      headers: { get: () => 'text/csv; charset=utf-8' },
+      blob: async () => new Blob([JSON.stringify(body)], { type: 'text/csv' }),
+    } as unknown as Response
+  }
+
+  const origCreate = URL.createObjectURL
+  const origRevoke = URL.revokeObjectURL
+  afterEach(() => {
+    URL.createObjectURL = origCreate
+    URL.revokeObjectURL = origRevoke
+  })
+
+  function stubDownload() {
+    URL.createObjectURL = vi.fn(() => 'blob:stub')
+    URL.revokeObjectURL = vi.fn()
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  }
+
+  it('encodes format, filter, sort, and column subset into the query string', async () => {
+    stubDownload()
+    fetchMock.mockResolvedValueOnce(downloadResponse([]))
+    const filter: FilterGroup = {
+      type: 'group',
+      combinator: 'and',
+      children: [{ type: 'condition', column: 'age', op: 'gt', value: 18 }],
+    }
+    await exportTableData('conn-1', 'users', 'csv', {
+      filter,
+      sort: [{ column: 'name', direction: 'asc' }],
+      columns: ['id', 'name'],
+    })
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(((init as RequestInit).headers as Record<string, string>)['x-connection-id']).toBe('conn-1')
+    const qs = new URL(url as string, 'http://x').searchParams
+    expect(qs.get('format')).toBe('csv')
+    expect(JSON.parse(qs.get('filter')!)).toEqual(filter)
+    expect(JSON.parse(qs.get('sort')!)).toEqual([{ column: 'name', direction: 'asc' }])
+    expect(JSON.parse(qs.get('columns')!)).toEqual(['id', 'name'])
+  })
+
+  it('omits empty filter and reports bytes streamed', async () => {
+    stubDownload()
+    fetchMock.mockResolvedValueOnce(downloadResponse([{ id: 1 }]))
+    const result = await exportTableData('conn-1', 'users', 'json', {
+      filter: { type: 'group', combinator: 'and', children: [] },
+    })
+    const [url] = fetchMock.mock.calls[0]
+    const qs = new URL(url as string, 'http://x').searchParams
+    expect(qs.has('filter')).toBe(false)
+    expect(result.bytes).toBeGreaterThan(0)
+  })
+
+  it('throws ApiError on a failed export', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ error: { code: 'BAD_REQUEST', message: 'Unknown export column(s): nope' } }, { status: 400 }),
+    )
+    await expect(
+      exportTableData('conn-1', 'users', 'csv', { columns: ['nope'] }),
+    ).rejects.toBeInstanceOf(ApiError)
   })
 })

--- a/client-next/test/unit/csv.test.ts
+++ b/client-next/test/unit/csv.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseCsv } from '@/lib/csv'
+
+describe('parseCsv', () => {
+  it('parses a simple header + rows', () => {
+    const { headers, rows } = parseCsv('id,name\n1,Ann\n2,Bob')
+    expect(headers).toEqual(['id', 'name'])
+    expect(rows).toEqual([
+      ['1', 'Ann'],
+      ['2', 'Bob'],
+    ])
+  })
+
+  it('handles quoted fields with commas, quotes, and newlines', () => {
+    const text = 'a,b\n"x,y","say ""hi"""\n"line1\nline2",z'
+    const { rows } = parseCsv(text)
+    expect(rows).toEqual([
+      ['x,y', 'say "hi"'],
+      ['line1\nline2', 'z'],
+    ])
+  })
+
+  it('handles CRLF line endings', () => {
+    const { headers, rows } = parseCsv('id,name\r\n1,Ann\r\n')
+    expect(headers).toEqual(['id', 'name'])
+    expect(rows).toEqual([['1', 'Ann']])
+  })
+
+  it('ignores a trailing newline without emitting an empty row', () => {
+    const { rows } = parseCsv('id\n1\n2\n')
+    expect(rows).toEqual([['1'], ['2']])
+  })
+
+  it('strips a leading UTF-8 BOM from the first header', () => {
+    const { headers } = parseCsv('﻿id,name\n1,Ann')
+    expect(headers).toEqual(['id', 'name'])
+  })
+
+  it('pads short rows and truncates overflow to the header width', () => {
+    const { rows } = parseCsv('a,b,c\n1,2\n1,2,3,4')
+    expect(rows).toEqual([
+      ['1', '2', ''],
+      ['1', '2', '3'],
+    ])
+  })
+
+  it('synthesizes headers when hasHeader is false', () => {
+    const { headers, rows } = parseCsv('1,Ann\n2,Bob', { hasHeader: false })
+    expect(headers).toEqual(['column_1', 'column_2'])
+    expect(rows).toEqual([
+      ['1', 'Ann'],
+      ['2', 'Bob'],
+    ])
+  })
+
+  it('supports a custom delimiter', () => {
+    const { headers, rows } = parseCsv('id\tname\n1\tAnn', { delimiter: '\t' })
+    expect(headers).toEqual(['id', 'name'])
+    expect(rows).toEqual([['1', 'Ann']])
+  })
+
+  it('returns empty result for empty input', () => {
+    expect(parseCsv('')).toEqual({ headers: [], rows: [] })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pglens",
-  "version": "3.0.2",
-  "description": "A simple PostgreSQL database viewer tool",
+  "version": "3.1.0",
+  "description": "A no-code PostgreSQL workstation: browse, filter, edit, and query your databases from a fast local web UI",
   "bin": {
     "pglens": "./bin/pglens"
   },

--- a/src/config/paths.js
+++ b/src/config/paths.js
@@ -11,6 +11,7 @@ const LOG_DIR = path.join(PGLENS_DIR, 'logs');
 const LOG_FILE = path.join(LOG_DIR, 'pglens.log');
 const TOKEN_FILE = path.join(PGLENS_DIR, 'token');
 const CONNECTIONS_FILE = path.join(PGLENS_DIR, 'connections.json');
+const VIEWS_FILE = path.join(PGLENS_DIR, 'views.json');
 const PID_FILE = path.join(os.homedir(), '.pglens.pid');
 const PORT_FILE = path.join(os.homedir(), '.pglens.port');
 
@@ -31,6 +32,7 @@ module.exports = {
   LOG_FILE,
   TOKEN_FILE,
   CONNECTIONS_FILE,
+  VIEWS_FILE,
   PID_FILE,
   PORT_FILE,
   ensureDir,

--- a/src/db/aggregate.js
+++ b/src/db/aggregate.js
@@ -1,0 +1,132 @@
+/**
+ * Per-column aggregations against the current filter.
+ *
+ * The UI sends a spec (never raw SQL): an array of { column, fn }. We validate
+ * each column against the table metadata and each function against the column's
+ * type, quote identifiers, and run a single one-row SELECT that reuses the same
+ * `WHERE` + params as the data read. Counts come back as strings (bigint) and
+ * numeric aggregates may come back as strings (numeric); the client formats.
+ *
+ * Allowed functions by column kind (roadmap §4.7):
+ *   numeric      count, count_distinct, sum, avg, min, max, stddev
+ *   text/date    count, count_distinct, min, max
+ *   boolean      count, count_distinct, count_true, count_false
+ */
+
+const { z } = require('zod');
+const { getPool } = require('./connection');
+const { quoteIdent } = require('./identifier');
+
+const NUMERIC_FNS = new Set(['count', 'count_distinct', 'sum', 'avg', 'min', 'max', 'stddev']);
+const TEXT_DATE_FNS = new Set(['count', 'count_distinct', 'min', 'max']);
+const BOOLEAN_FNS = new Set(['count', 'count_distinct', 'count_true', 'count_false']);
+const ALL_FNS = new Set([...NUMERIC_FNS, ...TEXT_DATE_FNS, ...BOOLEAN_FNS]);
+
+const MAX_AGGS = 100;
+
+const NUMERIC_RE = /(int|numeric|decimal|real|double|serial|money)/;
+
+const AggItemSchema = z.object({
+  column: z.string().min(1).max(255).refine((s) => !s.includes('\0'), 'null byte'),
+  fn: z.string().refine((f) => ALL_FNS.has(f), 'unknown aggregate function'),
+});
+
+const AggregateSpecSchema = z.array(AggItemSchema).max(MAX_AGGS);
+
+/** Bucket a column's data_type into the kind that gates which functions apply. */
+function columnKind(dataType) {
+  const t = (dataType || '').toLowerCase();
+  if (t.includes('bool')) return 'boolean';
+  if (NUMERIC_RE.test(t)) return 'numeric';
+  return 'other';
+}
+
+function allowedFns(kind) {
+  if (kind === 'numeric') return NUMERIC_FNS;
+  if (kind === 'boolean') return BOOLEAN_FNS;
+  return TEXT_DATE_FNS;
+}
+
+/** SQL expression for one aggregate. `col` is already quoted. */
+function aggExpr(fn, col) {
+  switch (fn) {
+    case 'count': return `COUNT(${col})`;
+    case 'count_distinct': return `COUNT(DISTINCT ${col})`;
+    case 'sum': return `SUM(${col})`;
+    case 'avg': return `AVG(${col})`;
+    case 'min': return `MIN(${col})`;
+    case 'max': return `MAX(${col})`;
+    case 'stddev': return `STDDEV(${col})`;
+    case 'count_true': return `COUNT(*) FILTER (WHERE ${col} IS TRUE)`;
+    case 'count_false': return `COUNT(*) FILTER (WHERE ${col} IS FALSE)`;
+    default:
+      // Schema validation already rejects unknown fns; this guards the switch.
+      throw new Error(`Unhandled aggregate function: ${fn}`);
+  }
+}
+
+/**
+ * Validate the spec against the table's columns and build the SELECT list. Each
+ * item becomes `<expr> AS a<i>` so results map back by index. Throws a 400 on an
+ * unknown column or a function the column's type doesn't support.
+ *
+ * @returns {{ items: Array<{column,fn}>, selectSql: string }}  selectSql is
+ *   empty when there are no items; callers should short-circuit in that case.
+ */
+function buildAggregateSelect(aggs, columnMetadata) {
+  if (aggs == null) return { items: [], selectSql: '' };
+
+  const parsed = AggregateSpecSchema.safeParse(aggs);
+  if (!parsed.success) {
+    const err = new Error(`Invalid aggregate spec: ${parsed.error.issues[0]?.message ?? 'parse error'}`);
+    err.statusCode = 400;
+    throw err;
+  }
+  const items = parsed.data;
+  if (items.length === 0) return { items: [], selectSql: '' };
+
+  const selects = items.map((item, i) => {
+    const meta = columnMetadata[item.column];
+    if (!meta) {
+      const err = new Error(`Unknown column: ${item.column}`);
+      err.statusCode = 400;
+      throw err;
+    }
+    const kind = columnKind(meta.dataType);
+    if (!allowedFns(kind).has(item.fn)) {
+      const err = new Error(`${item.fn} is not valid on ${meta.dataType} column "${item.column}"`);
+      err.statusCode = 400;
+      throw err;
+    }
+    return `${aggExpr(item.fn, quoteIdent(item.column))} AS a${i}`;
+  });
+
+  return { items, selectSql: selects.join(', ') };
+}
+
+/**
+ * Validate + run the aggregate spec. `whereSql`/`params` come from buildWhere so
+ * aggregations honor the active filter. Returns one result per requested item,
+ * in request order.
+ *
+ * @returns {Promise<{ results: Array<{ column: string, fn: string, value: unknown }> }>}
+ */
+async function computeAggregates(connectionId, qualifiedTable, { aggs, columnMetadata, whereSql, params }) {
+  const { items, selectSql } = buildAggregateSelect(aggs, columnMetadata);
+  if (items.length === 0) return { results: [] };
+
+  const pool = getPool(connectionId);
+  const sql = `SELECT ${selectSql} FROM ${qualifiedTable}${whereSql}`;
+  const result = await pool.query(sql, params);
+  const row = result.rows[0] ?? {};
+
+  return {
+    results: items.map((item, i) => ({
+      column: item.column,
+      fn: item.fn,
+      value: row[`a${i}`] ?? null,
+    })),
+  };
+}
+
+module.exports = { computeAggregates, buildAggregateSelect, AggregateSpecSchema, MAX_AGGS };

--- a/src/db/connection.js
+++ b/src/db/connection.js
@@ -49,6 +49,14 @@ function createPoolWrapper(sqlClient) {
         reserved.release();
       }
     },
+    /**
+     * Stream a query in server-side cursor batches. `onBatch(rows)` is awaited
+     * before the next batch is fetched, so callers writing to an HTTP response
+     * can apply backpressure (await `drain`) and the whole result set never has
+     * to materialize in memory — this is what keeps large-table exports flat.
+     */
+    cursor: (queryText, params, batchSize, onBatch) =>
+      sqlClient.unsafe(queryText, params || []).cursor(batchSize, onBatch),
     end: () => sqlClient.end(),
   };
 }

--- a/src/db/connection.js
+++ b/src/db/connection.js
@@ -57,6 +57,24 @@ function createPoolWrapper(sqlClient) {
      */
     cursor: (queryText, params, batchSize, onBatch) =>
       sqlClient.unsafe(queryText, params || []).cursor(batchSize, onBatch),
+    /**
+     * Run `handler(tx)` inside a single transaction. porsager's `.begin`
+     * COMMITs when the handler resolves and ROLLBACKs (re-throwing) when it
+     * rejects, so a multi-statement import is atomic — any failed batch undoes
+     * the whole import. The `tx` handed to the handler exposes the same
+     * `{ rows, rowCount }` shape as `query()`. A dry run rolls back simply by
+     * throwing once the counts are gathered.
+     */
+    transaction: (handler) =>
+      sqlClient.begin(async (sql) => {
+        const tx = {
+          query: async (queryText, params) => {
+            const result = await sql.unsafe(queryText, params || []);
+            return { rows: result, fields: result.columns || [], rowCount: result.count };
+          },
+        };
+        return handler(tx);
+      }),
     end: () => sqlClient.end(),
   };
 }

--- a/src/db/export.js
+++ b/src/db/export.js
@@ -1,0 +1,124 @@
+/**
+ * Per-table data export serializers.
+ *
+ * Pure, streaming-friendly formatters for CSV / JSON / SQL `INSERT` output.
+ * A serializer is a small object with `head()`, `row(rowObj)`, and `foot()`
+ * methods that each return a string chunk. The route writes those chunks
+ * straight to the HTTP response as cursor batches arrive, so no format buffers
+ * the full result set.
+ *
+ * Identifiers are pre-quoted by the caller's column list; these functions only
+ * format *values*, and never interpolate user-supplied SQL.
+ */
+
+const { quoteIdent } = require('./identifier');
+
+const EXPORT_FORMATS = ['csv', 'json', 'sql'];
+
+const FORMAT_META = {
+  csv: { contentType: 'text/csv; charset=utf-8', extension: 'csv' },
+  json: { contentType: 'application/json; charset=utf-8', extension: 'json' },
+  sql: { contentType: 'application/sql; charset=utf-8', extension: 'sql' },
+};
+
+// ---- CSV (RFC 4180) ---------------------------------------------------------
+
+/** Stringify a value for a CSV cell (pre-quoting). null/undefined → empty. */
+function csvScalar(value) {
+  if (value === null || value === undefined) return '';
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+/** Quote a CSV field only when it contains a delimiter, quote, or newline. */
+function csvField(value) {
+  const s = csvScalar(value);
+  if (/[",\r\n]/.test(s)) return `"${s.replaceAll('"', '""')}"`;
+  return s;
+}
+
+function csvRow(columns, row) {
+  return columns.map((c) => csvField(row[c])).join(',') + '\r\n';
+}
+
+// ---- SQL INSERT -------------------------------------------------------------
+
+/** Render a value as a SQL literal. Mirrors the logical-dump formatter. */
+function sqlLiteral(value) {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (value instanceof Date) return `'${value.toISOString()}'`;
+  if (Array.isArray(value)) {
+    const arr = value
+      .map((v) =>
+        v === null ? 'NULL'
+          : typeof v === 'string' ? `"${v.replaceAll('"', '""')}"`
+            : String(v),
+      )
+      .join(',');
+    return `'{${arr}}'`;
+  }
+  if (typeof value === 'object') return `'${JSON.stringify(value).replaceAll("'", "''")}'`;
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+// ---- Serializer factory -----------------------------------------------------
+
+/**
+ * @param {'csv'|'json'|'sql'} format
+ * @param {object} opts
+ * @param {string[]} opts.columns   Ordered column names to emit.
+ * @param {string}   opts.tableName Bare table name (for SQL `INSERT INTO`).
+ * @returns {{ head(): string, row(rowObj: object): string, foot(): string }}
+ */
+function createSerializer(format, { columns, tableName }) {
+  if (!EXPORT_FORMATS.includes(format)) {
+    throw new Error(`Unsupported export format: ${format}`);
+  }
+
+  if (format === 'csv') {
+    return {
+      head: () => columns.map(csvField).join(',') + '\r\n',
+      row: (rowObj) => csvRow(columns, rowObj),
+      foot: () => '',
+    };
+  }
+
+  if (format === 'json') {
+    let first = true;
+    return {
+      head: () => '[',
+      row: (rowObj) => {
+        // Project to the chosen columns in order so JSON matches CSV/SQL.
+        const projected = {};
+        for (const c of columns) projected[c] = rowObj[c];
+        const prefix = first ? '\n  ' : ',\n  ';
+        first = false;
+        return prefix + JSON.stringify(projected);
+      },
+      foot: () => (first ? ']\n' : '\n]\n'),
+    };
+  }
+
+  // sql
+  const target = quoteIdent(tableName);
+  const colList = columns.map(quoteIdent).join(', ');
+  return {
+    head: () => `-- pglens data export for ${target}\n\n`,
+    row: (rowObj) => {
+      const values = columns.map((c) => sqlLiteral(rowObj[c])).join(', ');
+      return `INSERT INTO ${target} (${colList}) VALUES (${values});\n`;
+    },
+    foot: () => '',
+  };
+}
+
+module.exports = {
+  EXPORT_FORMATS,
+  FORMAT_META,
+  createSerializer,
+  // exported for unit tests
+  csvField,
+  sqlLiteral,
+};

--- a/src/db/filter.js
+++ b/src/db/filter.js
@@ -1,0 +1,151 @@
+/**
+ * Visual filter spec → parameterized WHERE clause.
+ *
+ * The UI sends a structured spec (never raw SQL fragments). We validate it
+ * against the table's column metadata, then emit `WHERE ...` plus the
+ * `$1, $2, ...` parameter array. The data and count queries reuse the
+ * same params so a single bound array drives both.
+ *
+ * Spec shape (recursive):
+ *   Group     = { type: 'group', combinator: 'and'|'or', children: [...] }
+ *   Condition = { type: 'condition', column, op, value? }
+ *
+ * Supported operators (op → SQL fragment):
+ *   eq, neq, gt, gte, lt, lte   = | <> | > | >= | < | <=
+ *   like, ilike                  LIKE | ILIKE
+ *   in, nin                     = ANY($) | <> ALL($)        value: non-empty array
+ *   is_null, is_not_null         IS NULL | IS NOT NULL      (no value)
+ *   jsonb_contains              @> $::jsonb                 (jsonb columns only)
+ *   array_overlaps              && $                        (array columns only)
+ */
+
+const { z } = require('zod');
+const { quoteIdent } = require('./identifier');
+
+const OPS = new Set([
+  'eq', 'neq', 'gt', 'gte', 'lt', 'lte',
+  'like', 'ilike', 'in', 'nin',
+  'is_null', 'is_not_null',
+  'jsonb_contains', 'array_overlaps',
+]);
+const VALUELESS_OPS = new Set(['is_null', 'is_not_null']);
+const ARRAY_OPS = new Set(['in', 'nin', 'array_overlaps']);
+
+const MAX_DEPTH = 5;
+const MAX_CONDITIONS = 50;
+
+const ConditionSchema = z.object({
+  type: z.literal('condition'),
+  column: z.string().min(1).max(255).refine(s => !s.includes('\0'), 'null byte'),
+  op: z.string().refine(o => OPS.has(o), 'unknown operator'),
+  value: z.unknown().optional(),
+});
+
+const GroupSchema = z.lazy(() => z.object({
+  type: z.literal('group'),
+  combinator: z.enum(['and', 'or']),
+  children: z.array(z.union([ConditionSchema, GroupSchema])),
+}));
+
+const FilterSpecSchema = GroupSchema;
+
+/**
+ * @param {object} spec
+ * @param {object} columnMetadata  shape from getTableMetadata().columns
+ * @returns {{ sql: string, params: unknown[] }}  sql is empty when spec has no
+ *   conditions; callers should not prepend "WHERE" in that case.
+ */
+function buildWhere(spec, columnMetadata) {
+  if (spec == null) return { sql: '', params: [] };
+
+  const parsed = FilterSpecSchema.safeParse(spec);
+  if (!parsed.success) {
+    throw new Error(`Invalid filter spec: ${parsed.error.issues[0]?.message ?? 'parse error'}`);
+  }
+
+  const state = { params: [], conditionCount: 0 };
+  const inner = buildNode(parsed.data, columnMetadata, state, 0);
+  if (!inner) return { sql: '', params: [] };
+  return { sql: ` WHERE ${inner}`, params: state.params };
+}
+
+function buildNode(node, columns, state, depth) {
+  if (depth > MAX_DEPTH) {
+    throw new Error(`Filter nesting exceeds max depth of ${MAX_DEPTH}`);
+  }
+  if (node.type === 'group') {
+    const parts = [];
+    for (const child of node.children) {
+      const piece = buildNode(child, columns, state, depth + 1);
+      if (piece) parts.push(piece);
+    }
+    if (parts.length === 0) return '';
+    if (parts.length === 1) return parts[0];
+    return `(${parts.join(node.combinator === 'or' ? ' OR ' : ' AND ')})`;
+  }
+  return buildCondition(node, columns, state);
+}
+
+function buildCondition(node, columns, state) {
+  state.conditionCount += 1;
+  if (state.conditionCount > MAX_CONDITIONS) {
+    throw new Error(`Filter exceeds max of ${MAX_CONDITIONS} conditions`);
+  }
+
+  const meta = columns[node.column];
+  if (!meta) throw new Error(`Unknown column: ${node.column}`);
+
+  const col = quoteIdent(node.column);
+  const op = node.op;
+
+  if (VALUELESS_OPS.has(op)) {
+    return `${col} ${op === 'is_null' ? 'IS NULL' : 'IS NOT NULL'}`;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(node, 'value')) {
+    throw new Error(`Operator ${op} requires a value`);
+  }
+
+  if (ARRAY_OPS.has(op)) {
+    if (!Array.isArray(node.value) || node.value.length === 0) {
+      throw new Error(`Operator ${op} requires a non-empty array`);
+    }
+  }
+
+  if (op === 'like' || op === 'ilike') {
+    if (typeof node.value !== 'string') {
+      throw new Error(`${op} requires a string value`);
+    }
+  }
+
+  if (op === 'jsonb_contains') {
+    const t = (meta.dataType || '').toLowerCase();
+    if (t !== 'jsonb' && t !== 'json') {
+      throw new Error(`jsonb_contains is only valid on json/jsonb columns`);
+    }
+    const json = typeof node.value === 'string'
+      ? node.value
+      : JSON.stringify(node.value);
+    state.params.push(json);
+    return `${col} @> $${state.params.length}::jsonb`;
+  }
+
+  switch (op) {
+    case 'eq':  state.params.push(node.value); return `${col} = $${state.params.length}`;
+    case 'neq': state.params.push(node.value); return `${col} <> $${state.params.length}`;
+    case 'gt':  state.params.push(node.value); return `${col} > $${state.params.length}`;
+    case 'gte': state.params.push(node.value); return `${col} >= $${state.params.length}`;
+    case 'lt':  state.params.push(node.value); return `${col} < $${state.params.length}`;
+    case 'lte': state.params.push(node.value); return `${col} <= $${state.params.length}`;
+    case 'like':  state.params.push(node.value); return `${col} LIKE $${state.params.length}`;
+    case 'ilike': state.params.push(node.value); return `${col} ILIKE $${state.params.length}`;
+    case 'in':  state.params.push(node.value); return `${col} = ANY($${state.params.length})`;
+    case 'nin': state.params.push(node.value); return `${col} <> ALL($${state.params.length})`;
+    case 'array_overlaps': state.params.push(node.value); return `${col} && $${state.params.length}`;
+    default:
+      // Schema validation already rejects unknown ops; this guards the switch.
+      throw new Error(`Unhandled operator: ${op}`);
+  }
+}
+
+module.exports = { buildWhere, FilterSpecSchema, MAX_DEPTH, MAX_CONDITIONS };

--- a/src/db/import.js
+++ b/src/db/import.js
@@ -1,0 +1,167 @@
+/**
+ * Per-table CSV import → parameterized multi-row INSERT.
+ *
+ * Translates a block of already-parsed CSV rows (the client parses the file
+ * and projects each row to the target columns the user mapped) into a single
+ * parameterized statement of the form:
+ *
+ *   INSERT INTO "schema"."table" ("a", "b")
+ *   VALUES ($1, $2::jsonb), ($3, $4::jsonb), ...
+ *   ON CONFLICT (...) DO UPDATE SET ...
+ *   RETURNING (xmax = 0) AS pglens_inserted
+ *
+ * Three conflict modes mirror the roadmap's import wizard:
+ *   - `insert` : plain INSERT. Any unique/PK collision aborts the statement
+ *                (and, in the route, the surrounding transaction).
+ *   - `skip`   : INSERT ... ON CONFLICT DO NOTHING. Colliding rows are dropped.
+ *   - `update` : INSERT ... ON CONFLICT (<conflict cols>) DO UPDATE SET ...
+ *                Colliding rows overwrite the matched row's non-key columns.
+ *
+ * The `RETURNING (xmax = 0)` flag is the standard Postgres idiom for telling an
+ * inserted row (system xmax 0) apart from one the upsert updated, so the route
+ * can report inserted-vs-updated counts. Rows that DO NOTHING skips are simply
+ * absent from RETURNING — `attempted - returned` is the conflict count.
+ *
+ * Identifiers go through the shared escaper; cell values never reach the SQL
+ * string — they ride the driver as bound parameters.
+ */
+
+const { quoteIdent } = require('./identifier');
+
+const IMPORT_MODES = ['insert', 'skip', 'update'];
+
+// Postgres caps a single bound statement at 65535 parameters. The route splits
+// rows into batches so `batchRows * columns` stays under this; the builder
+// itself just enforces the hard ceiling as a guard.
+const MAX_BOUND_PARAMS = 65535;
+
+/** Per-column cast suffix. Only json/jsonb need an explicit cast; the driver
+ * infers everything else from the target column's type. */
+function columnCast(meta) {
+  const t = (meta?.dataType || '').toLowerCase();
+  if (t === 'jsonb' || t === 'json') return `::${t}`;
+  return '';
+}
+
+/**
+ * Normalize one raw CSV cell to the value bound for its column.
+ *   - `null`/`undefined` → SQL NULL.
+ *   - empty string → NULL when `emptyAsNull` (the import default), so blank
+ *     cells don't fail NOT-NULL-less numeric/date columns; otherwise the empty
+ *     string passes through (meaningful for text columns).
+ *   - everything else passes through as the parsed string; Postgres casts it to
+ *     the column type via the INSERT's target-column context.
+ */
+function coerceCell(raw, emptyAsNull) {
+  if (raw === null || raw === undefined) return null;
+  if (raw === '' && emptyAsNull) return null;
+  return raw;
+}
+
+/**
+ * @param {object}   opts
+ * @param {string}   opts.qualifiedTable  pre-quoted "schema"."table"
+ * @param {string[]} opts.targetColumns   ordered target column names
+ * @param {Record<string, { dataType: string }>} opts.columnMeta
+ * @param {Array<Array<unknown>>} opts.rows  cells aligned to targetColumns
+ * @param {'insert'|'skip'|'update'} opts.mode
+ * @param {string[]} [opts.conflictColumns] required for `update`
+ * @param {boolean}  [opts.emptyAsNull=true]
+ * @returns {{ sql: string, params: unknown[] }}
+ */
+function buildImportStatement(opts) {
+  const {
+    qualifiedTable, targetColumns, columnMeta, rows, mode,
+    conflictColumns = [], emptyAsNull = true,
+  } = opts;
+
+  if (!IMPORT_MODES.includes(mode)) {
+    throw new Error(`Unknown import mode: ${mode}`);
+  }
+  if (!Array.isArray(targetColumns) || targetColumns.length === 0) {
+    throw new Error('At least one target column is required');
+  }
+  if (new Set(targetColumns).size !== targetColumns.length) {
+    throw new Error('Duplicate target column in mapping');
+  }
+  for (const c of targetColumns) {
+    if (!Object.prototype.hasOwnProperty.call(columnMeta, c)) {
+      throw new Error(`Unknown column: ${c}`);
+    }
+  }
+  if (!Array.isArray(rows) || rows.length === 0) {
+    throw new Error('No rows to import');
+  }
+  if (rows.length * targetColumns.length > MAX_BOUND_PARAMS) {
+    throw new Error(
+      `Batch of ${rows.length} rows × ${targetColumns.length} columns exceeds the ${MAX_BOUND_PARAMS}-parameter limit`,
+    );
+  }
+
+  const colIdents = targetColumns.map(quoteIdent);
+  const casts = targetColumns.map((c) => columnCast(columnMeta[c]));
+
+  const params = [];
+  const tuples = rows.map((row) => {
+    if (!Array.isArray(row) || row.length !== targetColumns.length) {
+      throw new Error(
+        `Row has ${Array.isArray(row) ? row.length : 'non-array'} cells, expected ${targetColumns.length}`,
+      );
+    }
+    const placeholders = targetColumns.map((_, i) => {
+      params.push(coerceCell(row[i], emptyAsNull));
+      return `$${params.length}${casts[i]}`;
+    });
+    return `(${placeholders.join(', ')})`;
+  });
+
+  let conflict = '';
+  if (mode === 'skip') {
+    conflict = ' ON CONFLICT DO NOTHING';
+  } else if (mode === 'update') {
+    if (!Array.isArray(conflictColumns) || conflictColumns.length === 0) {
+      throw new Error('Update mode requires at least one conflict column');
+    }
+    for (const c of conflictColumns) {
+      if (!targetColumns.includes(c)) {
+        throw new Error(`Conflict column "${c}" must be one of the mapped columns`);
+      }
+    }
+    const updateCols = targetColumns.filter((c) => !conflictColumns.includes(c));
+    const target = conflictColumns.map(quoteIdent).join(', ');
+    if (updateCols.length === 0) {
+      // Nothing to overwrite (only key columns mapped) — degrade to a skip so
+      // the statement stays valid instead of `DO UPDATE SET` with no columns.
+      conflict = ` ON CONFLICT (${target}) DO NOTHING`;
+    } else {
+      const setList = updateCols
+        .map((c) => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`)
+        .join(', ');
+      conflict = ` ON CONFLICT (${target}) DO UPDATE SET ${setList}`;
+    }
+  }
+
+  const sql =
+    `INSERT INTO ${qualifiedTable} (${colIdents.join(', ')})` +
+    ` VALUES ${tuples.join(', ')}${conflict}` +
+    ` RETURNING (xmax = 0) AS pglens_inserted`;
+
+  return { sql, params };
+}
+
+/** Largest row count that keeps `rows * columns` under the bound-param limit,
+ * leaving headroom. Used by the route to split a big import into statements. */
+function batchSizeFor(columnCount) {
+  if (columnCount <= 0) return 1;
+  return Math.max(1, Math.floor(MAX_BOUND_PARAMS / columnCount));
+}
+
+module.exports = {
+  IMPORT_MODES,
+  MAX_BOUND_PARAMS,
+  buildImportStatement,
+  batchSizeFor,
+  // exported for unit tests
+  coerceCell,
+  columnCast,
+};

--- a/src/db/insert.js
+++ b/src/db/insert.js
@@ -1,0 +1,94 @@
+/**
+ * Row insert form → parameterized INSERT.
+ *
+ * Translates `{ values: { col: value, ... } }` into a single parameterized
+ * statement of the form:
+ *
+ *   INSERT INTO "schema"."table" ("col", "col2")
+ *   VALUES ($1, $2::jsonb)
+ *   RETURNING *
+ *
+ * Rules:
+ *   - Only columns present in `values` are written; every omitted column falls
+ *     back to its DEFAULT (or NULL). This is how the form's "use default"
+ *     affordance maps to SQL — the column simply isn't in the INSERT.
+ *   - An empty `values` object emits `DEFAULT VALUES`, inserting a row that is
+ *     entirely defaults (valid when every column is nullable or has a default).
+ *   - `values` keys must be known columns; unknown columns 400.
+ *   - json/jsonb values that arrive as objects/arrays get JSON.stringify'd and
+ *     cast as `::json` / `::jsonb`; everything else rides through the driver's
+ *     native type coercion. A SQL NULL is sent as a bare param (no cast) so the
+ *     column is set to NULL rather than the JSON string "null".
+ *
+ * Identifier quoting goes through the shared escaper so mixed-case columns
+ * work; user-supplied values never reach the SQL string. NOT NULL / CHECK /
+ * unique violations are left for Postgres to raise — the route surfaces them
+ * through the standard error envelope.
+ */
+
+const { quoteIdent } = require('./identifier');
+
+// Postgres caps a table at 1600 columns; nothing valid can exceed that.
+const MAX_INSERT_COLUMNS = 1600;
+
+function formatValue(value, meta, baseIdx) {
+  const type = (meta?.dataType || '').toLowerCase();
+  if (value !== null && (type === 'jsonb' || type === 'json')) {
+    // The driver doesn't auto-stringify objects for jsonb, so do it here and
+    // cast explicitly. A pre-stringified value passes through unchanged.
+    const json = typeof value === 'string' ? value : JSON.stringify(value);
+    return { fragment: `$${baseIdx + 1}::${type}`, params: [json] };
+  }
+  return { fragment: `$${baseIdx + 1}`, params: [value] };
+}
+
+/**
+ * @param {{ values: Record<string, unknown> }} spec
+ * @param {Record<string, { dataType: string, ... }>} columns
+ * @param {string} qualifiedTable  pre-quoted "schema"."table"
+ * @returns {{ sql: string, params: unknown[] }}
+ */
+function buildInsertRow(spec, columns, qualifiedTable) {
+  if (!spec || typeof spec !== 'object') {
+    throw new Error('Insert payload must be an object');
+  }
+  const { values } = spec;
+  if (!values || typeof values !== 'object' || Array.isArray(values)) {
+    throw new Error('`values` must be an object of column values');
+  }
+
+  const keys = Object.keys(values);
+  if (keys.length > MAX_INSERT_COLUMNS) {
+    throw new Error(`Cannot insert more than ${MAX_INSERT_COLUMNS} columns at once`);
+  }
+  for (const k of keys) {
+    if (!Object.prototype.hasOwnProperty.call(columns, k)) {
+      throw new Error(`Unknown column: ${k}`);
+    }
+  }
+
+  // No columns supplied → every column takes its DEFAULT.
+  if (keys.length === 0) {
+    return {
+      sql: `INSERT INTO ${qualifiedTable} DEFAULT VALUES RETURNING *`,
+      params: [],
+    };
+  }
+
+  const params = [];
+  const colFragments = keys.map((k) => quoteIdent(k));
+  const valFragments = keys.map((k) => {
+    const { fragment, params: added } = formatValue(values[k], columns[k], params.length);
+    params.push(...added);
+    return fragment;
+  });
+
+  return {
+    sql:
+      `INSERT INTO ${qualifiedTable} (${colFragments.join(', ')})` +
+      ` VALUES (${valFragments.join(', ')}) RETURNING *`,
+    params,
+  };
+}
+
+module.exports = { buildInsertRow, MAX_INSERT_COLUMNS };

--- a/src/db/sort.js
+++ b/src/db/sort.js
@@ -1,0 +1,75 @@
+/**
+ * Visual sort spec → ORDER BY clause.
+ *
+ * The UI sends a structured array of `{column, direction}` entries (priority
+ * is array order). We validate every column against the table's metadata and
+ * the direction against an allowlist, then emit a safely-quoted identifier
+ * list. No user-supplied string ever lands in SQL without going through
+ * `quoteIdent` + a direction whitelist.
+ *
+ * Spec shape:
+ *   SortSpec = Array<{ column: string, direction: 'asc' | 'desc' }>
+ */
+
+const { z } = require('zod');
+const { quoteIdent } = require('./identifier');
+
+const MAX_SORTS = 10;
+
+const SortEntrySchema = z.object({
+  column: z.string().min(1).max(255).refine((s) => !s.includes('\0'), 'null byte'),
+  direction: z.enum(['asc', 'desc', 'ASC', 'DESC']),
+});
+
+const SortSpecSchema = z.array(SortEntrySchema).max(MAX_SORTS);
+
+/**
+ * @param {unknown} spec
+ * @param {object} columnMetadata  shape from getTableMetadata().columns
+ * @param {string|null} primaryKeyColumn  appended as final tie-break when not
+ *   already part of the user sort
+ * @returns {{ sql: string, columns: string[] }}  sql is empty when there's no
+ *   user sort and no PK to fall back on; callers should not prepend "ORDER BY"
+ *   in that case. `columns` is the resolved sort columns in priority order
+ *   (useful for legacy single-column callers).
+ */
+function buildOrderBy(spec, columnMetadata, primaryKeyColumn = null) {
+  const entries = normalize(spec, columnMetadata);
+
+  const parts = entries.map(
+    (e) => `${quoteIdent(e.column)} ${e.direction.toUpperCase()}`,
+  );
+
+  if (primaryKeyColumn && !entries.some((e) => e.column === primaryKeyColumn)) {
+    parts.push(`${quoteIdent(primaryKeyColumn)} ASC`);
+  }
+
+  if (parts.length === 0) return { sql: '', columns: [] };
+  return {
+    sql: ` ORDER BY ${parts.join(', ')}`,
+    columns: entries.map((e) => e.column),
+  };
+}
+
+function normalize(spec, columnMetadata) {
+  if (spec == null) return [];
+  const parsed = SortSpecSchema.safeParse(spec);
+  if (!parsed.success) {
+    throw new Error(`Invalid sort spec: ${parsed.error.issues[0]?.message ?? 'parse error'}`);
+  }
+  const seen = new Set();
+  const out = [];
+  for (const entry of parsed.data) {
+    if (!columnMetadata[entry.column]) {
+      throw new Error(`Unknown sort column: ${entry.column}`);
+    }
+    // Dedup — a column appearing twice would emit redundant SQL; keep first
+    // occurrence so priority order is preserved.
+    if (seen.has(entry.column)) continue;
+    seen.add(entry.column);
+    out.push(entry);
+  }
+  return out;
+}
+
+module.exports = { buildOrderBy, SortSpecSchema, MAX_SORTS };

--- a/src/db/update.js
+++ b/src/db/update.js
@@ -1,0 +1,109 @@
+/**
+ * Inline edit → parameterized UPDATE.
+ *
+ * Translates `{ where: { pk: value, ... }, set: { col: value, ... } }` into a
+ * single parameterized statement of the form:
+ *
+ *   UPDATE "schema"."table"
+ *   SET "col" = $1, "col2" = $2::jsonb, ...
+ *   WHERE "pk1" = $n AND "pk2" = $n+1
+ *   RETURNING *
+ *
+ * Rules:
+ *   - The `where` keys MUST be exactly the table's primary-key columns (so a
+ *     stale edit can never UPDATE more than one row).
+ *   - The `set` keys must be known columns. Empty `set` is rejected.
+ *   - json/jsonb values that arrive as objects/arrays get JSON.stringify'd and
+ *     cast as `::json` / `::jsonb`; everything else rides through the driver's
+ *     native type coercion.
+ *
+ * Identifier quoting goes through the shared escaper so mixed-case columns
+ * work; user-supplied values never reach the SQL string.
+ */
+
+const { quoteIdent } = require('./identifier');
+
+const MAX_SET_COLUMNS = 200;
+
+function formatValue(value, meta, baseIdx) {
+  const type = (meta?.dataType || '').toLowerCase();
+  if (value !== null && (type === 'jsonb' || type === 'json')) {
+    // The driver doesn't auto-stringify objects for jsonb, so do it here and
+    // cast explicitly. A pre-stringified value passes through unchanged.
+    const json = typeof value === 'string' ? value : JSON.stringify(value);
+    return { fragment: `$${baseIdx + 1}::${type}`, params: [json] };
+  }
+  return { fragment: `$${baseIdx + 1}`, params: [value] };
+}
+
+/**
+ * @param {{ where: Record<string, unknown>, set: Record<string, unknown> }} spec
+ * @param {Record<string, { dataType: string, isPrimaryKey: boolean, ... }>} columns
+ * @param {string} qualifiedTable  pre-quoted "schema"."table"
+ * @returns {{ sql: string, params: unknown[] }}
+ */
+function buildUpdateRow(spec, columns, qualifiedTable) {
+  if (!spec || typeof spec !== 'object') {
+    throw new Error('Update payload must be an object');
+  }
+  const { where, set } = spec;
+  if (!where || typeof where !== 'object' || Array.isArray(where)) {
+    throw new Error('`where` must be an object of primary-key columns');
+  }
+  if (!set || typeof set !== 'object' || Array.isArray(set)) {
+    throw new Error('`set` must be an object of column updates');
+  }
+
+  const pkCols = Object.keys(columns).filter((c) => columns[c].isPrimaryKey);
+  if (pkCols.length === 0) {
+    throw new Error('Table has no primary key — inline editing requires one');
+  }
+
+  const setKeys = Object.keys(set);
+  if (setKeys.length === 0) {
+    throw new Error('`set` must include at least one column');
+  }
+  if (setKeys.length > MAX_SET_COLUMNS) {
+    throw new Error(`Cannot update more than ${MAX_SET_COLUMNS} columns at once`);
+  }
+  for (const k of setKeys) {
+    if (!Object.prototype.hasOwnProperty.call(columns, k)) {
+      throw new Error(`Unknown column: ${k}`);
+    }
+  }
+
+  const whereKeys = Object.keys(where);
+  // Allow PK columns in any order, but every PK must appear and no non-PK keys
+  // are accepted — keeps the UPDATE pinned to exactly one row.
+  for (const k of whereKeys) {
+    if (!pkCols.includes(k)) {
+      throw new Error(`\`where\` only accepts primary-key columns; got: ${k}`);
+    }
+  }
+  if (whereKeys.length !== pkCols.length) {
+    throw new Error(
+      `\`where\` must include every primary-key column (${pkCols.join(', ')})`,
+    );
+  }
+
+  const params = [];
+  const setFragments = setKeys.map((k) => {
+    const { fragment, params: added } = formatValue(set[k], columns[k], params.length);
+    params.push(...added);
+    return `${quoteIdent(k)} = ${fragment}`;
+  });
+  const whereFragments = pkCols.map((k) => {
+    const { fragment, params: added } = formatValue(where[k], columns[k], params.length);
+    params.push(...added);
+    return `${quoteIdent(k)} = ${fragment}`;
+  });
+
+  return {
+    sql:
+      `UPDATE ${qualifiedTable} SET ${setFragments.join(', ')}` +
+      ` WHERE ${whereFragments.join(' AND ')} RETURNING *`,
+    params,
+  };
+}
+
+module.exports = { buildUpdateRow, MAX_SET_COLUMNS };

--- a/src/db/views.js
+++ b/src/db/views.js
@@ -1,0 +1,207 @@
+/**
+ * Saved Views store.
+ *
+ * A "view" bundles (filter + sort + visible columns + column widths +
+ * timezone) for a single (connectionId, tableName) pair. Persisted to
+ * `~/.pglens/views.json` as a flat array of records and written atomically
+ * (tmp file + rename) so a crash mid-write can't leave a half-flushed JSON
+ * blob in place.
+ *
+ * The store is intentionally schema-aware about the *envelope* (id, name,
+ * connection, table, timestamps) but treats the filter/sort payloads as
+ * opaque blobs — they're re-validated against the live column metadata in
+ * `buildWhere` / `buildOrderBy` on each request, so persisting a stale spec
+ * fails closed at read time instead of failing here.
+ */
+
+const fs = require('fs');
+const crypto = require('crypto');
+const { z } = require('zod');
+
+const logger = require('../log');
+const { VIEWS_FILE, ensureLayout } = require('../config/paths');
+
+const MAX_NAME_LEN = 120;
+const MAX_VIEWS = 1000;
+
+// Filter/sort payloads are validated structurally here, then re-validated
+// against the live column metadata inside buildWhere/buildOrderBy when the
+// view is actually loaded. The shapes mirror src/db/filter.js + src/db/sort.js.
+const FilterConditionSchema = z.object({
+  type: z.literal('condition'),
+  column: z.string().min(1).max(255),
+  op: z.string().min(1).max(40),
+  value: z.unknown().optional(),
+});
+const FilterGroupSchema = z.lazy(() =>
+  z.object({
+    type: z.literal('group'),
+    combinator: z.enum(['and', 'or']),
+    children: z.array(z.union([FilterConditionSchema, FilterGroupSchema])),
+  }),
+);
+const SortEntrySchema = z.object({
+  column: z.string().min(1).max(255),
+  direction: z.enum(['asc', 'desc', 'ASC', 'DESC']),
+});
+
+const ViewBodySchema = z.object({
+  connectionId: z.string().min(1).max(255),
+  tableName: z.string().min(1).max(255),
+  name: z.string().min(1).max(MAX_NAME_LEN),
+  filter: FilterGroupSchema.nullable().optional(),
+  sort: z.array(SortEntrySchema).max(50).optional(),
+  visibleColumns: z.array(z.string().max(255)).max(500).nullable().optional(),
+  columnWidths: z.record(z.string(), z.number().int().positive().max(4000))
+    .nullable().optional(),
+  timezone: z.string().max(64).nullable().optional(),
+});
+
+const ViewPatchSchema = ViewBodySchema.partial().refine(
+  (v) => Object.keys(v).length > 0,
+  { message: 'patch must change at least one field' },
+);
+
+// In-memory mirror of the JSON file. `null` until first load.
+let cache = null;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+/**
+ * Atomic write: serialize → write to a sibling tmp path → rename onto the
+ * real path. Rename is atomic on the same filesystem; a crash mid-write
+ * leaves the previous version intact rather than a truncated JSON file.
+ */
+function writeAtomic(payload) {
+  ensureLayout();
+  const tmp = `${VIEWS_FILE}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, VIEWS_FILE);
+}
+
+function load() {
+  if (cache) return cache;
+  try {
+    const raw = fs.readFileSync(VIEWS_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.views)) {
+      logger.warn({ file: VIEWS_FILE }, 'views.json malformed — starting empty');
+      cache = { views: [] };
+    } else {
+      cache = { views: parsed.views };
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      logger.warn({ err: err.message }, 'views.json read failed — starting empty');
+    }
+    cache = { views: [] };
+  }
+  return cache;
+}
+
+function persist() {
+  writeAtomic(cache);
+}
+
+function listViews({ connectionId, tableName } = {}) {
+  const all = load().views;
+  return all.filter(
+    (v) =>
+      (!connectionId || v.connectionId === connectionId) &&
+      (!tableName || v.tableName === tableName),
+  );
+}
+
+function getView(id) {
+  return load().views.find((v) => v.id === id) || null;
+}
+
+function createView(body) {
+  const parsed = ViewBodySchema.parse(body);
+  const all = load().views;
+  if (all.length >= MAX_VIEWS) {
+    throw new Error(`Too many saved views (limit ${MAX_VIEWS})`);
+  }
+  const dup = all.find(
+    (v) =>
+      v.connectionId === parsed.connectionId &&
+      v.tableName === parsed.tableName &&
+      v.name === parsed.name,
+  );
+  if (dup) {
+    throw new Error(`A view named "${parsed.name}" already exists for this table`);
+  }
+  const view = {
+    id: crypto.randomUUID(),
+    connectionId: parsed.connectionId,
+    tableName: parsed.tableName,
+    name: parsed.name,
+    filter: parsed.filter ?? null,
+    sort: parsed.sort ?? [],
+    visibleColumns: parsed.visibleColumns ?? null,
+    columnWidths: parsed.columnWidths ?? null,
+    timezone: parsed.timezone ?? null,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+  };
+  all.push(view);
+  persist();
+  return view;
+}
+
+function updateView(id, patch) {
+  const parsed = ViewPatchSchema.parse(patch);
+  const all = load().views;
+  const idx = all.findIndex((v) => v.id === id);
+  if (idx < 0) return null;
+  const cur = all[idx];
+
+  // Name uniqueness per (connection, table). Allow renaming, but block a
+  // rename onto an existing sibling's name.
+  if (parsed.name && parsed.name !== cur.name) {
+    const targetConn = parsed.connectionId ?? cur.connectionId;
+    const targetTable = parsed.tableName ?? cur.tableName;
+    const dup = all.find(
+      (v) =>
+        v.id !== id &&
+        v.connectionId === targetConn &&
+        v.tableName === targetTable &&
+        v.name === parsed.name,
+    );
+    if (dup) {
+      throw new Error(`A view named "${parsed.name}" already exists for this table`);
+    }
+  }
+
+  const next = { ...cur, ...parsed, id: cur.id, createdAt: cur.createdAt, updatedAt: nowIso() };
+  all[idx] = next;
+  persist();
+  return next;
+}
+
+function deleteView(id) {
+  const all = load().views;
+  const idx = all.findIndex((v) => v.id === id);
+  if (idx < 0) return false;
+  all.splice(idx, 1);
+  persist();
+  return true;
+}
+
+/** Test-only — wipe the in-memory cache so a fresh fs read happens next call. */
+function _resetForTests() {
+  cache = null;
+}
+
+module.exports = {
+  listViews,
+  getView,
+  createView,
+  updateView,
+  deleteView,
+  ViewBodySchema,
+  ViewPatchSchema,
+  _resetForTests,
+};

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -15,6 +15,7 @@ const {
   getConnectionSchema, updateConnectionSchema, updateConnection,
 } = require('../db/connection');
 const { quoteIdent, quoteQualifiedIdent } = require('../db/identifier');
+const { buildWhere } = require('../db/filter');
 const { sendError, codes } = require('../http/errors');
 const { validate } = require('../http/validate');
 const logger = require('../log');
@@ -42,6 +43,8 @@ const TableListQuery = z.object({
   cursor: z.union([z.string(), z.number()]).optional(),
   sortColumn: z.string().min(1).optional(),
   sortDirection: z.enum(['asc', 'desc', 'ASC', 'DESC']).optional(),
+  // JSON-encoded filter spec (validated structurally by buildWhere).
+  filter: z.string().max(64_000).optional(),
 });
 
 const QueryBodySchema = z.object({
@@ -298,13 +301,38 @@ router.get('/tables/:tableName',
         return sendError(res, 400, codes.BAD_REQUEST, 'Invalid sort column');
       }
 
+      // Parse the structured filter spec once. The Zod-validated shape +
+      // column-existence check happen inside buildWhere; surface any error
+      // as a 400 so the user can fix the bar input.
+      let filterSpec = null;
+      if (req.query.filter) {
+        try {
+          filterSpec = JSON.parse(req.query.filter);
+        } catch {
+          return sendError(res, 400, codes.BAD_REQUEST, 'Invalid filter JSON');
+        }
+      }
+      let whereClause = '', whereParams = [];
+      try {
+        ({ sql: whereClause, params: whereParams } = buildWhere(filterSpec, columnMetadata));
+      } catch (err) {
+        return sendError(res, 400, codes.BAD_REQUEST, err.message);
+      }
+      const hasFilter = whereClause !== '';
+
       // COUNT and the data query are independent — run them concurrently to
       // collapse two latency round-trips into one. The data query is built
       // inline below; count runs alongside it.
-      const countPromise = pool.query(`SELECT COUNT(*) as total FROM ${qualifiedTable}`);
+      const countPromise = pool.query(
+        `SELECT COUNT(*) as total FROM ${qualifiedTable}${whereClause}`,
+        whereParams,
+      );
       // Build the data query without awaiting, so it runs alongside the count.
       // `emitCursor` marks branches where nextCursor is the last row's PK.
+      // Cursor pagination is disabled when a filter is applied — the cursor's
+      // "next PK > $1" assumption only holds against the unfiltered row order.
       let dataPromise, emitCursor = false;
+      const nextParam = (i) => `$${whereParams.length + i}`;
 
       if (sortColumn) {
         const offset = (page - 1) * limit;
@@ -313,16 +341,16 @@ router.get('/tables/:tableName',
           orderByClause += `, ${quoteIdent(primaryKeyColumn)} ASC`;
         }
         dataPromise = pool.query(
-          `SELECT * FROM ${qualifiedTable} ${orderByClause} LIMIT $1 OFFSET $2`,
-          [limit, offset],
+          `SELECT * FROM ${qualifiedTable}${whereClause} ${orderByClause} LIMIT ${nextParam(1)} OFFSET ${nextParam(2)}`,
+          [...whereParams, limit, offset],
         );
-      } else if (primaryKeyColumn && cursor !== undefined) {
+      } else if (!hasFilter && primaryKeyColumn && cursor !== undefined) {
         dataPromise = pool.query(
           `SELECT * FROM ${qualifiedTable} WHERE ${quoteIdent(primaryKeyColumn)} > $1 ORDER BY ${quoteIdent(primaryKeyColumn)} ASC LIMIT $2`,
           [cursor, limit],
         );
         emitCursor = true;
-      } else if (primaryKeyColumn && page === 1) {
+      } else if (!hasFilter && primaryKeyColumn && page === 1) {
         dataPromise = pool.query(
           `SELECT * FROM ${qualifiedTable} ORDER BY ${quoteIdent(primaryKeyColumn)} ASC LIMIT $1`,
           [limit],
@@ -332,10 +360,10 @@ router.get('/tables/:tableName',
         const offset = (page - 1) * limit;
         const orderBy = primaryKeyColumn ? `ORDER BY ${quoteIdent(primaryKeyColumn)} ASC ` : '';
         dataPromise = pool.query(
-          `SELECT * FROM ${qualifiedTable} ${orderBy}LIMIT $1 OFFSET $2`,
-          [limit, offset],
+          `SELECT * FROM ${qualifiedTable}${whereClause} ${orderBy}LIMIT ${nextParam(1)} OFFSET ${nextParam(2)}`,
+          [...whereParams, limit, offset],
         );
-        emitCursor = !!primaryKeyColumn;
+        emitCursor = !hasFilter && !!primaryKeyColumn;
       }
 
       const [countResult, dataResult] = await Promise.all([countPromise, dataPromise]);

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -20,7 +20,7 @@ const { buildOrderBy } = require('../db/sort');
 const { computeAggregates } = require('../db/aggregate');
 const { buildUpdateRow } = require('../db/update');
 const { buildInsertRow } = require('../db/insert');
-const { EXPORT_FORMATS, FORMAT_META, createSerializer } = require('../db/export');
+const { EXPORT_FORMATS, FORMAT_META, createSerializer, sqlLiteral } = require('../db/export');
 const { IMPORT_MODES, buildImportStatement, batchSizeFor } = require('../db/import');
 const views = require('../db/views');
 const { sendError, codes } = require('../http/errors');
@@ -917,18 +917,7 @@ router.get('/export', requireConnection, async (req, res) => {
       const rows = await pool.query(`SELECT * FROM ${quoteQualifiedIdent(schema, tableName)}`);
       for (const row of rows.rows) {
         const keys = Object.keys(row).map(k => quoteIdent(k)).join(', ');
-        const values = Object.values(row).map(val => {
-          if (val === null) return 'NULL';
-          if (typeof val === 'number' || typeof val === 'boolean') return val;
-          if (val instanceof Date) return `'${val.toISOString()}'`;
-          if (Array.isArray(val)) {
-            const arr = val.map(v => v === null ? 'NULL'
-              : typeof v === 'string' ? `"${v.replace(/"/g, '""')}"` : v).join(',');
-            return `'{${arr}}'`;
-          }
-          if (typeof val === 'object') return `'${JSON.stringify(val).replace(/'/g, "''")}'`;
-          return `'${String(val).replace(/'/g, "''")}'`;
-        }).join(', ');
+        const values = Object.values(row).map(sqlLiteral).join(', ');
         res.write(`INSERT INTO ${quoteIdent(tableName)} (${keys}) VALUES (${values});\n`);
       }
       res.write('\n');

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -20,6 +20,7 @@ const { buildOrderBy } = require('../db/sort');
 const { computeAggregates } = require('../db/aggregate');
 const { buildUpdateRow } = require('../db/update');
 const { buildInsertRow } = require('../db/insert');
+const { EXPORT_FORMATS, FORMAT_META, createSerializer } = require('../db/export');
 const views = require('../db/views');
 const { sendError, codes } = require('../http/errors');
 const { validate } = require('../http/validate');
@@ -489,6 +490,123 @@ router.get('/tables/:tableName/aggregate',
     } catch (err) {
       logger.error({ err: err.message, table: tableName }, 'aggregate failed');
       return sendError(res, 500, codes.DB_ERROR, err.message);
+    }
+  });
+
+// ---- Per-table data export --------------------------------------------------
+//
+// GET /api/tables/:tableName/export?format=csv|json|sql&filter=<json>&sort=<json>&columns=<json>
+//   Streams the table's rows in the chosen format, respecting the current
+//   filter, sort, and (optionally) a visible-column subset. Rows are pulled
+//   through a server-side cursor in batches and written straight to the
+//   response, so memory stays flat regardless of table size.
+
+const TableExportQuery = z.object({
+  format: z.enum(EXPORT_FORMATS).default('csv'),
+  filter: z.string().max(64_000).optional(),
+  sort: z.string().max(8_000).optional(),
+  // JSON array of column names to include (defaults to all, in ordinal order).
+  columns: z.string().max(64_000).optional(),
+  // Hard cap on rows emitted. Omitted ⇒ every matching row.
+  limit: z.coerce.number().int().positive().max(10_000_000).optional(),
+});
+
+const EXPORT_BATCH_SIZE = 500;
+
+router.get('/tables/:tableName/export',
+  requireConnection,
+  validate({
+    params: z.object({ tableName: TableNameSchema }),
+    query: TableExportQuery,
+  }),
+  async (req, res) => {
+    const tableName = req.params.tableName;
+    const pool = req.pool;
+    const schema = req.schema;
+    const qualifiedTable = quoteQualifiedIdent(schema, tableName);
+    const { format, limit } = req.query;
+
+    try {
+      const { columns: columnMetadata, primaryKeyColumn } =
+        await getTableMetadata(pool, req.connectionId, schema, tableName);
+
+      // Parse the optional JSON params. Bad JSON is a user error → 400.
+      let filterSpec = null, sortSpec = null, requestedColumns = null;
+      try {
+        if (req.query.filter) filterSpec = JSON.parse(req.query.filter);
+        if (req.query.sort) sortSpec = JSON.parse(req.query.sort);
+        if (req.query.columns) requestedColumns = JSON.parse(req.query.columns);
+      } catch {
+        return sendError(res, 400, codes.BAD_REQUEST, 'Invalid filter, sort, or columns JSON');
+      }
+
+      // Resolve the columns to emit. A requested subset is whitelisted against
+      // real columns (preserving request order); unknown names are rejected so
+      // a typo can't silently drop data. Default is every column in ordinal
+      // order.
+      let exportColumns;
+      if (Array.isArray(requestedColumns) && requestedColumns.length > 0) {
+        const unknown = requestedColumns.filter((c) => !columnMetadata[c]);
+        if (unknown.length > 0) {
+          return sendError(res, 400, codes.BAD_REQUEST,
+            `Unknown export column(s): ${unknown.join(', ')}`);
+        }
+        exportColumns = requestedColumns;
+      } else {
+        exportColumns = Object.keys(columnMetadata);
+      }
+
+      let whereClause = '', whereParams = [];
+      try {
+        ({ sql: whereClause, params: whereParams } = buildWhere(filterSpec, columnMetadata));
+      } catch (err) {
+        return sendError(res, 400, codes.BAD_REQUEST, err.message);
+      }
+
+      let orderByClause = '';
+      try {
+        ({ sql: orderByClause } = buildOrderBy(sortSpec, columnMetadata, primaryKeyColumn));
+      } catch (err) {
+        return sendError(res, 400, codes.BAD_REQUEST, err.message);
+      }
+
+      const params = [...whereParams];
+      let limitClause = '';
+      if (limit) {
+        limitClause = ` LIMIT $${params.length + 1}`;
+        params.push(limit);
+      }
+      const colList = exportColumns.map(quoteIdent).join(', ');
+      const query =
+        `SELECT ${colList} FROM ${qualifiedTable}${whereClause}${orderByClause}${limitClause}`;
+
+      const meta = FORMAT_META[format];
+      const safeName = `${tableName}.${meta.extension}`.replace(/[^A-Za-z0-9._-]/g, '_');
+      res.setHeader('Content-Type', meta.contentType);
+      res.setHeader('Content-Disposition', `attachment; filename="${safeName}"`);
+
+      const serializer = createSerializer(format, { columns: exportColumns, tableName });
+
+      // Backpressure-aware write: pause cursor fetches while the socket drains.
+      const write = (chunk) =>
+        res.write(chunk) ? Promise.resolve() : new Promise((r) => res.once('drain', r));
+
+      await write(serializer.head());
+      await pool.cursor(query, params, EXPORT_BATCH_SIZE, async (rows) => {
+        let chunk = '';
+        for (const row of rows) chunk += serializer.row(row);
+        await write(chunk);
+      });
+      await write(serializer.foot());
+      res.end();
+    } catch (err) {
+      logger.error({ err: err.message, table: tableName }, 'table export failed');
+      // Once streaming has begun the status/headers are already flushed; the
+      // best we can do is terminate the (now-truncated) download.
+      if (!res.headersSent) {
+        return sendError(res, 500, codes.DB_ERROR, err.message);
+      }
+      res.end();
     }
   });
 

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -17,6 +17,7 @@ const {
 const { quoteIdent, quoteQualifiedIdent } = require('../db/identifier');
 const { buildWhere } = require('../db/filter');
 const { buildOrderBy } = require('../db/sort');
+const views = require('../db/views');
 const { sendError, codes } = require('../http/errors');
 const { validate } = require('../http/validate');
 const logger = require('../log');
@@ -586,6 +587,52 @@ router.get('/schema', requireConnection, async (req, res) => {
     logger.error({ err: err.message }, 'schema read failed');
     return sendError(res, 500, codes.DB_ERROR, err.message);
   }
+});
+
+// ---- Saved views ------------------------------------------------------------
+//
+// Views persist `(filter + sort + visible columns + column widths + timezone)`
+// per (connectionId, tableName). They live in `~/.pglens/views.json` — see
+// `src/db/views.js`. Listing is open (no `requireConnection`) so the sidebar
+// can show views even when the database isn't reachable.
+
+const ViewListQuery = z.object({
+  connectionId: z.string().min(1).max(255).optional(),
+  tableName: z.string().min(1).max(255).optional(),
+});
+
+const ViewIdParam = z.object({ id: z.string().uuid() });
+
+router.get('/views', validate({ query: ViewListQuery }), (req, res) => {
+  res.json({ views: views.listViews(req.query) });
+});
+
+router.post('/views', validate({ body: views.ViewBodySchema }), (req, res) => {
+  try {
+    res.status(201).json({ view: views.createView(req.body) });
+  } catch (err) {
+    return sendError(res, 400, codes.BAD_REQUEST, err.message);
+  }
+});
+
+router.put('/views/:id',
+  validate({ params: ViewIdParam, body: views.ViewPatchSchema }),
+  (req, res) => {
+    try {
+      const updated = views.updateView(req.params.id, req.body);
+      if (!updated) {
+        return sendError(res, 404, codes.NOT_FOUND, 'View not found');
+      }
+      res.json({ view: updated });
+    } catch (err) {
+      return sendError(res, 400, codes.BAD_REQUEST, err.message);
+    }
+  });
+
+router.delete('/views/:id', validate({ params: ViewIdParam }), (req, res) => {
+  const ok = views.deleteView(req.params.id);
+  if (!ok) return sendError(res, 404, codes.NOT_FOUND, 'View not found');
+  res.json({ deleted: true });
 });
 
 // ---- Raw-SQL escape hatch ---------------------------------------------------

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -17,6 +17,7 @@ const {
 const { quoteIdent, quoteQualifiedIdent } = require('../db/identifier');
 const { buildWhere } = require('../db/filter');
 const { buildOrderBy } = require('../db/sort');
+const { buildUpdateRow } = require('../db/update');
 const views = require('../db/views');
 const { sendError, codes } = require('../http/errors');
 const { validate } = require('../http/validate');
@@ -222,7 +223,7 @@ async function getForeignKeyRelations(pool, tableName, schema) {
 
 async function getColumnMetadata(pool, tableName, schema) {
   const r = await pool.query(`
-    SELECT column_name, data_type
+    SELECT column_name, data_type, udt_name, is_nullable, column_default
     FROM information_schema.columns
     WHERE table_schema = $2 AND table_name = $1
     ORDER BY ordinal_position;
@@ -236,8 +237,15 @@ async function getColumnMetadata(pool, tableName, schema) {
 
   const out = {};
   for (const row of r.rows) {
+    // `data_type` is the SQL standard name (e.g. "ARRAY", "USER-DEFINED").
+    // Surface the real Postgres type (`udt_name`, e.g. `int4`, `text`,
+    // `_text`, the enum name) so the editor can pick the right widget for
+    // arrays and enums.
     out[row.column_name] = {
       dataType: row.data_type,
+      udtName: row.udt_name,
+      isNullable: row.is_nullable === 'YES',
+      hasDefault: row.column_default !== null,
       isPrimaryKey: pkCols.has(row.column_name),
       isForeignKey: !!fkRels[row.column_name],
       foreignKeyRef: fkRels[row.column_name] || null,
@@ -409,6 +417,60 @@ router.get('/tables/:tableName',
     } catch (err) {
       logger.error({ err: err.message, table: req.params.tableName }, 'table read failed');
       return sendError(res, 500, codes.DB_ERROR, err.message);
+    }
+  });
+
+// ---- Inline row edit --------------------------------------------------------
+//
+// PATCH /api/tables/:tableName/rows
+//   Body: { where: { pk_col: value, ... }, set: { col: value, ... } }
+//   Returns: { row } — the freshly-updated row, post-trigger.
+//
+// `where` must list every primary-key column (so the UPDATE can only touch a
+// single row). `set` keys must be known columns; jsonb values get `::jsonb`
+// cast applied for us. Empty payloads, unknown columns, and missing PK
+// columns all 400 with a hint.
+
+const RowUpdateBodySchema = z.object({
+  where: z.record(z.string().min(1).max(255), z.unknown()),
+  set: z.record(z.string().min(1).max(255), z.unknown()),
+});
+
+router.patch('/tables/:tableName/rows',
+  requireConnection,
+  validate({
+    params: z.object({ tableName: TableNameSchema }),
+    body: RowUpdateBodySchema,
+  }),
+  async (req, res) => {
+    const tableName = req.params.tableName;
+    const pool = req.pool;
+    const schema = req.schema;
+    const qualifiedTable = quoteQualifiedIdent(schema, tableName);
+
+    try {
+      const { columns } = await getTableMetadata(pool, req.connectionId, schema, tableName);
+
+      let built;
+      try {
+        built = buildUpdateRow(req.body, columns, qualifiedTable);
+      } catch (err) {
+        return sendError(res, 400, codes.BAD_REQUEST, err.message);
+      }
+
+      const result = await pool.query(built.sql, built.params);
+      if (!result.rows.length) {
+        // Either the PK changed underneath us or the row was deleted. The
+        // client should refetch and replay the edit if still applicable.
+        return sendError(res, 404, codes.NOT_FOUND,
+          'Row not found — it may have been deleted or its primary key changed', {
+            hint: 'Refresh the table and try again.',
+          });
+      }
+      res.json({ row: result.rows[0] });
+    } catch (err) {
+      logger.warn({ err: err.message, table: tableName }, 'row update failed');
+      return sendError(res, 400, codes.DB_ERROR, err.message);
     }
   });
 

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -21,6 +21,7 @@ const { computeAggregates } = require('../db/aggregate');
 const { buildUpdateRow } = require('../db/update');
 const { buildInsertRow } = require('../db/insert');
 const { EXPORT_FORMATS, FORMAT_META, createSerializer } = require('../db/export');
+const { IMPORT_MODES, buildImportStatement, batchSizeFor } = require('../db/import');
 const views = require('../db/views');
 const { sendError, codes } = require('../http/errors');
 const { validate } = require('../http/validate');
@@ -607,6 +608,145 @@ router.get('/tables/:tableName/export',
         return sendError(res, 500, codes.DB_ERROR, err.message);
       }
       res.end();
+    }
+  });
+
+// ---- Per-table CSV import ---------------------------------------------------
+//
+// POST /api/tables/:tableName/import
+//   Body: {
+//     columns: string[],          // target columns, in order
+//     rows: unknown[][],          // each row's cells, aligned to `columns`
+//     mode: 'insert'|'skip'|'update',
+//     conflictColumns?: string[], // required for 'update' (the ON CONFLICT key)
+//     emptyAsNull?: boolean,      // blank cell → NULL (default true)
+//     dryRun?: boolean,           // count only, then roll back (default false)
+//   }
+//   Returns: { dryRun, mode, attempted, inserted, updated, conflicts, batches }
+//
+// The client parses the CSV file, maps headers → columns, and projects each
+// row to the chosen target columns; the server validates the columns, builds
+// parameterized multi-row INSERTs (batched under Postgres' 65535-param cap),
+// and runs every batch inside ONE transaction so the import is all-or-nothing.
+// A dry run runs the same statements then rolls back, reporting the counts the
+// real run would produce — for plain `insert` mode the dry run probes with
+// ON CONFLICT DO NOTHING so it can report conflicts without aborting.
+
+// 65535 params / 1 column ⇒ ~65k rows max per batch; cap total rows per request
+// well above any reasonable interactive paste while still bounding the body.
+const MAX_IMPORT_ROWS = 500_000;
+
+const ImportBodySchema = z.object({
+  columns: z.array(z.string().min(1).max(255)).min(1).max(1600),
+  rows: z.array(z.array(z.unknown())).min(1).max(MAX_IMPORT_ROWS),
+  mode: z.enum(IMPORT_MODES),
+  conflictColumns: z.array(z.string().min(1).max(255)).optional(),
+  emptyAsNull: z.boolean().optional(),
+  dryRun: z.boolean().optional(),
+});
+
+// Thrown to unwind porsager's transaction (forcing a ROLLBACK) once a dry run
+// has gathered its counts. Carries the tallies back out to the route.
+const ROLLBACK = Symbol('pglens-dry-run-rollback');
+
+router.post('/tables/:tableName/import',
+  requireConnection,
+  validate({
+    params: z.object({ tableName: TableNameSchema }),
+    body: ImportBodySchema,
+  }),
+  async (req, res) => {
+    const tableName = req.params.tableName;
+    const pool = req.pool;
+    const schema = req.schema;
+    const qualifiedTable = quoteQualifiedIdent(schema, tableName);
+    const {
+      columns: targetColumns, rows, mode,
+      conflictColumns = [], emptyAsNull = true, dryRun = false,
+    } = req.body;
+
+    try {
+      const { columns: columnMetadata } =
+        await getTableMetadata(pool, req.connectionId, schema, tableName);
+
+      // Validate the mapping up front so a bad column 400s before we open a
+      // transaction. (buildImportStatement re-checks, but this gives a cleaner
+      // single error rather than failing mid-batch.)
+      const unknown = targetColumns.filter((c) => !columnMetadata[c]);
+      if (unknown.length > 0) {
+        return sendError(res, 400, codes.BAD_REQUEST,
+          `Unknown column(s): ${unknown.join(', ')}`);
+      }
+      if (mode === 'update') {
+        if (conflictColumns.length === 0) {
+          return sendError(res, 400, codes.BAD_REQUEST,
+            'Update mode requires conflictColumns', {
+              hint: 'Map the table\'s primary-key or a unique column.',
+            });
+        }
+        const badConflict = conflictColumns.filter((c) => !targetColumns.includes(c));
+        if (badConflict.length > 0) {
+          return sendError(res, 400, codes.BAD_REQUEST,
+            `Conflict column(s) not in the mapping: ${badConflict.join(', ')}`);
+        }
+      }
+
+      // A plain-INSERT dry run can't report conflicts without aborting, so it
+      // probes with DO NOTHING. The real run uses the requested mode.
+      const planMode = dryRun && mode === 'insert' ? 'skip' : mode;
+      const batchSize = batchSizeFor(targetColumns.length);
+
+      const runImport = async (exec) => {
+        let attempted = 0, inserted = 0, updated = 0, batches = 0;
+        for (let i = 0; i < rows.length; i += batchSize) {
+          const batch = rows.slice(i, i + batchSize);
+          const { sql, params } = buildImportStatement({
+            qualifiedTable, targetColumns, columnMeta: columnMetadata,
+            rows: batch, mode: planMode, conflictColumns, emptyAsNull,
+          });
+          const result = await exec.query(sql, params);
+          attempted += batch.length;
+          batches += 1;
+          // RETURNING yields a row per affected row, flagged inserted vs
+          // updated by (xmax = 0). Rows DO NOTHING skipped are absent.
+          for (const r of result.rows) {
+            if (r.pglens_inserted) inserted += 1;
+            else updated += 1;
+          }
+        }
+        return { attempted, inserted, updated };
+      };
+
+      let counts;
+      if (dryRun) {
+        try {
+          await pool.transaction(async (tx) => {
+            counts = await runImport(tx);
+            throw ROLLBACK; // discard the probe writes
+          });
+        } catch (err) {
+          if (err !== ROLLBACK) throw err;
+        }
+      } else {
+        counts = await pool.transaction(runImport);
+      }
+
+      // `attempted - (inserted + updated)` is what ON CONFLICT dropped. For
+      // update mode nothing is dropped, so this is 0.
+      const conflicts = counts.attempted - counts.inserted - counts.updated;
+      res.json({
+        dryRun, mode,
+        attempted: counts.attempted,
+        inserted: counts.inserted,
+        updated: counts.updated,
+        conflicts,
+        batches: dryRun ? undefined : Math.ceil(rows.length / batchSize),
+      });
+    } catch (err) {
+      logger.warn({ err: err.message, table: tableName }, 'import failed');
+      return sendError(res, 400, codes.DB_ERROR, err.message, {
+        hint: dryRun ? undefined : 'No rows were imported — the transaction rolled back.',
+      });
     }
   });
 

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -16,6 +16,7 @@ const {
 } = require('../db/connection');
 const { quoteIdent, quoteQualifiedIdent } = require('../db/identifier');
 const { buildWhere } = require('../db/filter');
+const { buildOrderBy } = require('../db/sort');
 const { sendError, codes } = require('../http/errors');
 const { validate } = require('../http/validate');
 const logger = require('../log');
@@ -43,6 +44,9 @@ const TableListQuery = z.object({
   cursor: z.union([z.string(), z.number()]).optional(),
   sortColumn: z.string().min(1).optional(),
   sortDirection: z.enum(['asc', 'desc', 'ASC', 'DESC']).optional(),
+  // JSON-encoded multi-column sort spec (validated structurally by buildOrderBy).
+  // Wins over legacy sortColumn/sortDirection when both are sent.
+  sort: z.string().max(8_000).optional(),
   // JSON-encoded filter spec (validated structurally by buildWhere).
   filter: z.string().max(64_000).optional(),
 });
@@ -287,8 +291,6 @@ router.get('/tables/:tableName',
       const page = req.query.page || 1;
       const limit = req.query.limit || 100;
       const cursor = req.query.cursor;
-      const sortColumn = req.query.sortColumn || null;
-      const sortDirection = (req.query.sortDirection || 'asc').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
 
       const pool = req.pool;
       const schema = req.schema;
@@ -297,9 +299,23 @@ router.get('/tables/:tableName',
       const { columns: columnMetadata, primaryKeyColumn } =
         await getTableMetadata(pool, req.connectionId, schema, tableName);
 
-      if (sortColumn && !columnMetadata[sortColumn]) {
-        return sendError(res, 400, codes.BAD_REQUEST, 'Invalid sort column');
+      // Resolve the user sort spec. Prefer the structured `sort` array; fall
+      // back to legacy single-column `sortColumn`/`sortDirection` for the v2
+      // client and older v3 builds.
+      let sortSpec = null;
+      if (req.query.sort) {
+        try {
+          sortSpec = JSON.parse(req.query.sort);
+        } catch {
+          return sendError(res, 400, codes.BAD_REQUEST, 'Invalid sort JSON');
+        }
+      } else if (req.query.sortColumn) {
+        sortSpec = [{
+          column: req.query.sortColumn,
+          direction: (req.query.sortDirection || 'asc').toLowerCase() === 'desc' ? 'desc' : 'asc',
+        }];
       }
+      const hasUserSort = Array.isArray(sortSpec) && sortSpec.length > 0;
 
       // Parse the structured filter spec once. The Zod-validated shape +
       // column-existence check happen inside buildWhere; surface any error
@@ -320,6 +336,16 @@ router.get('/tables/:tableName',
       }
       const hasFilter = whereClause !== '';
 
+      // Resolve ORDER BY. The helper validates every column, whitelists the
+      // direction, quotes identifiers, and appends the PK as final tie-break
+      // when the user sort doesn't already include it.
+      let orderByClause = '';
+      try {
+        ({ sql: orderByClause } = buildOrderBy(sortSpec, columnMetadata, primaryKeyColumn));
+      } catch (err) {
+        return sendError(res, 400, codes.BAD_REQUEST, err.message);
+      }
+
       // COUNT and the data query are independent — run them concurrently to
       // collapse two latency round-trips into one. The data query is built
       // inline below; count runs alongside it.
@@ -329,38 +355,34 @@ router.get('/tables/:tableName',
       );
       // Build the data query without awaiting, so it runs alongside the count.
       // `emitCursor` marks branches where nextCursor is the last row's PK.
-      // Cursor pagination is disabled when a filter is applied — the cursor's
-      // "next PK > $1" assumption only holds against the unfiltered row order.
+      // Cursor pagination is disabled when a filter is applied OR a user sort
+      // is active — the cursor's "next PK > $1" assumption only holds against
+      // the default PK-ordered, unfiltered row stream.
       let dataPromise, emitCursor = false;
       const nextParam = (i) => `$${whereParams.length + i}`;
 
-      if (sortColumn) {
+      if (hasUserSort) {
         const offset = (page - 1) * limit;
-        let orderByClause = `ORDER BY ${quoteIdent(sortColumn)} ${sortDirection}`;
-        if (primaryKeyColumn && sortColumn !== primaryKeyColumn) {
-          orderByClause += `, ${quoteIdent(primaryKeyColumn)} ASC`;
-        }
         dataPromise = pool.query(
-          `SELECT * FROM ${qualifiedTable}${whereClause} ${orderByClause} LIMIT ${nextParam(1)} OFFSET ${nextParam(2)}`,
+          `SELECT * FROM ${qualifiedTable}${whereClause}${orderByClause} LIMIT ${nextParam(1)} OFFSET ${nextParam(2)}`,
           [...whereParams, limit, offset],
         );
       } else if (!hasFilter && primaryKeyColumn && cursor !== undefined) {
         dataPromise = pool.query(
-          `SELECT * FROM ${qualifiedTable} WHERE ${quoteIdent(primaryKeyColumn)} > $1 ORDER BY ${quoteIdent(primaryKeyColumn)} ASC LIMIT $2`,
+          `SELECT * FROM ${qualifiedTable} WHERE ${quoteIdent(primaryKeyColumn)} > $1${orderByClause} LIMIT $2`,
           [cursor, limit],
         );
         emitCursor = true;
       } else if (!hasFilter && primaryKeyColumn && page === 1) {
         dataPromise = pool.query(
-          `SELECT * FROM ${qualifiedTable} ORDER BY ${quoteIdent(primaryKeyColumn)} ASC LIMIT $1`,
+          `SELECT * FROM ${qualifiedTable}${orderByClause} LIMIT $1`,
           [limit],
         );
         emitCursor = true;
       } else {
         const offset = (page - 1) * limit;
-        const orderBy = primaryKeyColumn ? `ORDER BY ${quoteIdent(primaryKeyColumn)} ASC ` : '';
         dataPromise = pool.query(
-          `SELECT * FROM ${qualifiedTable}${whereClause} ${orderBy}LIMIT ${nextParam(1)} OFFSET ${nextParam(2)}`,
+          `SELECT * FROM ${qualifiedTable}${whereClause}${orderByClause} LIMIT ${nextParam(1)} OFFSET ${nextParam(2)}`,
           [...whereParams, limit, offset],
         );
         emitCursor = !hasFilter && !!primaryKeyColumn;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -18,6 +18,7 @@ const { quoteIdent, quoteQualifiedIdent } = require('../db/identifier');
 const { buildWhere } = require('../db/filter');
 const { buildOrderBy } = require('../db/sort');
 const { buildUpdateRow } = require('../db/update');
+const { buildInsertRow } = require('../db/insert');
 const views = require('../db/views');
 const { sendError, codes } = require('../http/errors');
 const { validate } = require('../http/validate');
@@ -246,6 +247,9 @@ async function getColumnMetadata(pool, tableName, schema) {
       udtName: row.udt_name,
       isNullable: row.is_nullable === 'YES',
       hasDefault: row.column_default !== null,
+      // Raw default expression (e.g. `nextval('seq')`, `now()`, `'active'::text`).
+      // The insert form ghosts this so the user knows what they're skipping.
+      defaultValue: row.column_default,
       isPrimaryKey: pkCols.has(row.column_name),
       isForeignKey: !!fkRels[row.column_name],
       foreignKeyRef: fkRels[row.column_name] || null,
@@ -470,6 +474,50 @@ router.patch('/tables/:tableName/rows',
       res.json({ row: result.rows[0] });
     } catch (err) {
       logger.warn({ err: err.message, table: tableName }, 'row update failed');
+      return sendError(res, 400, codes.DB_ERROR, err.message);
+    }
+  });
+
+// ---- Row insert -------------------------------------------------------------
+//
+// POST /api/tables/:tableName/rows
+//   Body: { values: { col: value, ... } }
+//   Returns: { row } — the freshly-inserted row, post-trigger/default.
+//
+// Columns omitted from `values` take their DEFAULT (or NULL); an empty object
+// inserts an all-defaults row. Unknown columns 400; NOT NULL / CHECK / unique
+// violations surface from Postgres through the error envelope.
+
+const RowInsertBodySchema = z.object({
+  values: z.record(z.string().min(1).max(255), z.unknown()),
+});
+
+router.post('/tables/:tableName/rows',
+  requireConnection,
+  validate({
+    params: z.object({ tableName: TableNameSchema }),
+    body: RowInsertBodySchema,
+  }),
+  async (req, res) => {
+    const tableName = req.params.tableName;
+    const pool = req.pool;
+    const schema = req.schema;
+    const qualifiedTable = quoteQualifiedIdent(schema, tableName);
+
+    try {
+      const { columns } = await getTableMetadata(pool, req.connectionId, schema, tableName);
+
+      let built;
+      try {
+        built = buildInsertRow(req.body, columns, qualifiedTable);
+      } catch (err) {
+        return sendError(res, 400, codes.BAD_REQUEST, err.message);
+      }
+
+      const result = await pool.query(built.sql, built.params);
+      res.status(201).json({ row: result.rows[0] });
+    } catch (err) {
+      logger.warn({ err: err.message, table: tableName }, 'row insert failed');
       return sendError(res, 400, codes.DB_ERROR, err.message);
     }
   });

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -17,6 +17,7 @@ const {
 const { quoteIdent, quoteQualifiedIdent } = require('../db/identifier');
 const { buildWhere } = require('../db/filter');
 const { buildOrderBy } = require('../db/sort');
+const { computeAggregates } = require('../db/aggregate');
 const { buildUpdateRow } = require('../db/update');
 const { buildInsertRow } = require('../db/insert');
 const views = require('../db/views');
@@ -420,6 +421,73 @@ router.get('/tables/:tableName',
       });
     } catch (err) {
       logger.error({ err: err.message, table: req.params.tableName }, 'table read failed');
+      return sendError(res, 500, codes.DB_ERROR, err.message);
+    }
+  });
+
+// ---- Aggregations strip -----------------------------------------------------
+//
+// GET /api/tables/:tableName/aggregate?filter=<json>&aggs=<json>
+//   Per-column aggregations (count/sum/avg/min/max/stddev/count distinct/
+//   count true|false) computed against the current filter. `aggs` is a JSON
+//   array of { column, fn }; returns { results: [{ column, fn, value }] } in
+//   request order. Functions are gated by column type server-side.
+
+const AggregateListQuery = z.object({
+  filter: z.string().max(64_000).optional(),
+  aggs: z.string().max(64_000).optional(),
+});
+
+router.get('/tables/:tableName/aggregate',
+  requireConnection,
+  validate({
+    params: z.object({ tableName: TableNameSchema }),
+    query: AggregateListQuery,
+  }),
+  async (req, res) => {
+    const tableName = req.params.tableName;
+    const pool = req.pool;
+    const schema = req.schema;
+    const qualifiedTable = quoteQualifiedIdent(schema, tableName);
+
+    try {
+      const { columns: columnMetadata } =
+        await getTableMetadata(pool, req.connectionId, schema, tableName);
+
+      let filterSpec = null, aggSpec = null;
+      try {
+        if (req.query.filter) filterSpec = JSON.parse(req.query.filter);
+        if (req.query.aggs) aggSpec = JSON.parse(req.query.aggs);
+      } catch {
+        return sendError(res, 400, codes.BAD_REQUEST, 'Invalid filter or aggs JSON');
+      }
+
+      let whereClause = '', whereParams = [];
+      try {
+        ({ sql: whereClause, params: whereParams } = buildWhere(filterSpec, columnMetadata));
+      } catch (err) {
+        return sendError(res, 400, codes.BAD_REQUEST, err.message);
+      }
+
+      let result;
+      try {
+        result = await computeAggregates(req.connectionId, qualifiedTable, {
+          aggs: aggSpec,
+          columnMetadata,
+          whereSql: whereClause,
+          params: whereParams,
+        });
+      } catch (err) {
+        // computeAggregates flags user errors (bad column/fn) with statusCode 400.
+        if (err.statusCode === 400) {
+          return sendError(res, 400, codes.BAD_REQUEST, err.message);
+        }
+        throw err;
+      }
+
+      res.json(result);
+    } catch (err) {
+      logger.error({ err: err.message, table: tableName }, 'aggregate failed');
       return sendError(res, 500, codes.DB_ERROR, err.message);
     }
   });

--- a/test/unit/aggregate.test.js
+++ b/test/unit/aggregate.test.js
@@ -1,0 +1,84 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildAggregateSelect } = require('../../src/db/aggregate');
+
+const columns = {
+  id: { dataType: 'integer' },
+  price: { dataType: 'numeric' },
+  name: { dataType: 'text' },
+  created_at: { dataType: 'timestamp with time zone' },
+  active: { dataType: 'boolean' },
+};
+
+function selectOf(aggs) {
+  return buildAggregateSelect(aggs, columns).selectSql;
+}
+
+test('null / empty spec yields nothing', () => {
+  assert.equal(buildAggregateSelect(null, columns).selectSql, '');
+  assert.equal(buildAggregateSelect([], columns).selectSql, '');
+});
+
+test('numeric functions on a numeric column', () => {
+  assert.equal(
+    selectOf([
+      { column: 'price', fn: 'sum' },
+      { column: 'price', fn: 'avg' },
+    ]),
+    'SUM("price") AS a0, AVG("price") AS a1',
+  );
+});
+
+test('count distinct on text', () => {
+  assert.equal(
+    selectOf([{ column: 'name', fn: 'count_distinct' }]),
+    'COUNT(DISTINCT "name") AS a0',
+  );
+});
+
+test('boolean count_true / count_false use FILTER', () => {
+  assert.equal(
+    selectOf([
+      { column: 'active', fn: 'count_true' },
+      { column: 'active', fn: 'count_false' },
+    ]),
+    'COUNT(*) FILTER (WHERE "active" IS TRUE) AS a0, COUNT(*) FILTER (WHERE "active" IS FALSE) AS a1',
+  );
+});
+
+test('unknown column rejected', () => {
+  assert.throws(
+    () => selectOf([{ column: 'nope', fn: 'count' }]),
+    /Unknown column/,
+  );
+});
+
+test('sum on a text column rejected', () => {
+  assert.throws(
+    () => selectOf([{ column: 'name', fn: 'sum' }]),
+    /not valid on/,
+  );
+});
+
+test('sum on a boolean column rejected', () => {
+  assert.throws(
+    () => selectOf([{ column: 'active', fn: 'sum' }]),
+    /not valid on/,
+  );
+});
+
+test('unknown function rejected', () => {
+  assert.throws(
+    () => selectOf([{ column: 'price', fn: 'median' }]),
+    /unknown aggregate function/,
+  );
+});
+
+test('identifiers with quotes are escaped', () => {
+  const cols = { 'weird"col': { dataType: 'integer' } };
+  assert.equal(
+    buildAggregateSelect([{ column: 'weird"col', fn: 'max' }], cols).selectSql,
+    'MAX("weird""col") AS a0',
+  );
+});

--- a/test/unit/export.test.js
+++ b/test/unit/export.test.js
@@ -1,0 +1,122 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  EXPORT_FORMATS, FORMAT_META, createSerializer, csvField, sqlLiteral,
+} = require('../../src/db/export');
+
+// ---- csvField ---------------------------------------------------------------
+
+test('csvField leaves plain values unquoted', () => {
+  assert.equal(csvField('hello'), 'hello');
+  assert.equal(csvField(42), '42');
+  assert.equal(csvField(true), 'true');
+});
+
+test('csvField renders null/undefined as empty', () => {
+  assert.equal(csvField(null), '');
+  assert.equal(csvField(undefined), '');
+});
+
+test('csvField quotes and escapes delimiters, quotes, and newlines', () => {
+  assert.equal(csvField('a,b'), '"a,b"');
+  assert.equal(csvField('say "hi"'), '"say ""hi"""');
+  assert.equal(csvField('line1\nline2'), '"line1\nline2"');
+});
+
+test('csvField serializes objects/arrays as JSON', () => {
+  // Object JSON contains `"`, so the field is CSV-quoted and quotes doubled.
+  assert.equal(csvField({ a: 1 }), '"{""a"":1}"');
+  // Array JSON contains `,`, so it too is CSV-quoted.
+  assert.equal(csvField([1, 2]), '"[1,2]"');
+});
+
+test('csvField renders Date as ISO', () => {
+  assert.equal(csvField(new Date('2020-01-02T03:04:05.000Z')), '2020-01-02T03:04:05.000Z');
+});
+
+// ---- sqlLiteral -------------------------------------------------------------
+
+test('sqlLiteral handles nulls, numbers, booleans', () => {
+  assert.equal(sqlLiteral(null), 'NULL');
+  assert.equal(sqlLiteral(undefined), 'NULL');
+  assert.equal(sqlLiteral(7), '7');
+  assert.equal(sqlLiteral(false), 'false');
+});
+
+test('sqlLiteral escapes single quotes in strings', () => {
+  assert.equal(sqlLiteral("O'Brien"), "'O''Brien'");
+});
+
+test('sqlLiteral renders arrays as a Postgres array literal', () => {
+  assert.equal(sqlLiteral(['a', 'b']), `'{"a","b"}'`);
+  assert.equal(sqlLiteral([1, null, 3]), `'{1,NULL,3}'`);
+});
+
+test('sqlLiteral renders objects as quoted JSON with escaped quotes', () => {
+  assert.equal(sqlLiteral({ k: "x'y" }), `'{"k":"x''y"}'`);
+});
+
+// ---- serializer: csv --------------------------------------------------------
+
+test('csv serializer emits header then rows in column order', () => {
+  const s = createSerializer('csv', { columns: ['id', 'name'], tableName: 't' });
+  assert.equal(s.head(), 'id,name\r\n');
+  assert.equal(s.row({ id: 1, name: 'Ann', extra: 'ignored' }), '1,Ann\r\n');
+  assert.equal(s.row({ id: 2, name: 'a,b' }), '2,"a,b"\r\n');
+  assert.equal(s.foot(), '');
+});
+
+// ---- serializer: json -------------------------------------------------------
+
+test('json serializer brackets an array and commas between rows', () => {
+  const s = createSerializer('json', { columns: ['id'], tableName: 't' });
+  let out = s.head();
+  out += s.row({ id: 1 });
+  out += s.row({ id: 2 });
+  out += s.foot();
+  assert.deepEqual(JSON.parse(out), [{ id: 1 }, { id: 2 }]);
+});
+
+test('json serializer emits a valid empty array with no rows', () => {
+  const s = createSerializer('json', { columns: ['id'], tableName: 't' });
+  const out = s.head() + s.foot();
+  assert.deepEqual(JSON.parse(out), []);
+});
+
+test('json serializer projects only the chosen columns', () => {
+  const s = createSerializer('json', { columns: ['id'], tableName: 't' });
+  const out = s.head() + s.row({ id: 1, secret: 'x' }) + s.foot();
+  assert.deepEqual(JSON.parse(out), [{ id: 1 }]);
+});
+
+// ---- serializer: sql --------------------------------------------------------
+
+test('sql serializer emits INSERT statements with quoted identifiers', () => {
+  const s = createSerializer('sql', { columns: ['id', 'name'], tableName: 'users' });
+  assert.match(s.head(), /-- pglens data export for "users"/);
+  assert.equal(
+    s.row({ id: 1, name: "O'Brien" }),
+    `INSERT INTO "users" ("id", "name") VALUES (1, 'O''Brien');\n`,
+  );
+});
+
+test('sql serializer quotes a table name containing a double quote', () => {
+  const s = createSerializer('sql', { columns: ['a'], tableName: 'we"ird' });
+  assert.equal(s.row({ a: 1 }), `INSERT INTO "we""ird" ("a") VALUES (1);\n`);
+});
+
+// ---- guards -----------------------------------------------------------------
+
+test('unknown format throws', () => {
+  assert.throws(() => createSerializer('xml', { columns: [], tableName: 't' }),
+    /Unsupported export format/);
+});
+
+test('FORMAT_META covers every supported format', () => {
+  for (const f of EXPORT_FORMATS) {
+    assert.ok(FORMAT_META[f], `missing meta for ${f}`);
+    assert.ok(FORMAT_META[f].extension);
+    assert.ok(FORMAT_META[f].contentType);
+  }
+});

--- a/test/unit/filter.test.js
+++ b/test/unit/filter.test.js
@@ -1,0 +1,167 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildWhere, MAX_DEPTH, MAX_CONDITIONS } = require('../../src/db/filter');
+
+const cols = {
+  id: { dataType: 'integer', isPrimaryKey: true, isForeignKey: false, foreignKeyRef: null, isUnique: true },
+  name: { dataType: 'text', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false },
+  status: { dataType: 'text', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false },
+  payload: { dataType: 'jsonb', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false },
+  tags: { dataType: 'text[]', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false },
+};
+
+test('buildWhere returns empty for null spec', () => {
+  assert.deepEqual(buildWhere(null, cols), { sql: '', params: [] });
+});
+
+test('buildWhere returns empty for an empty group', () => {
+  const { sql, params } = buildWhere(
+    { type: 'group', combinator: 'and', children: [] }, cols,
+  );
+  assert.equal(sql, '');
+  assert.deepEqual(params, []);
+});
+
+test('single equality emits parameterized = $1', () => {
+  const { sql, params } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'status', op: 'eq', value: 'active' }],
+  }, cols);
+  assert.equal(sql, ' WHERE "status" = $1');
+  assert.deepEqual(params, ['active']);
+});
+
+test('multi-condition AND wraps in parens with sequential params', () => {
+  const { sql, params } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [
+      { type: 'condition', column: 'status', op: 'eq', value: 'active' },
+      { type: 'condition', column: 'id', op: 'gt', value: 100 },
+    ],
+  }, cols);
+  assert.equal(sql, ' WHERE ("status" = $1 AND "id" > $2)');
+  assert.deepEqual(params, ['active', 100]);
+});
+
+test('nested groups produce parenthesized OR/AND', () => {
+  const { sql } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [
+      { type: 'condition', column: 'status', op: 'eq', value: 'a' },
+      {
+        type: 'group', combinator: 'or',
+        children: [
+          { type: 'condition', column: 'id', op: 'lt', value: 10 },
+          { type: 'condition', column: 'id', op: 'gt', value: 100 },
+        ],
+      },
+    ],
+  }, cols);
+  assert.equal(sql, ' WHERE ("status" = $1 AND ("id" < $2 OR "id" > $3))');
+});
+
+test('IS NULL / IS NOT NULL have no params', () => {
+  const { sql, params } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [
+      { type: 'condition', column: 'name', op: 'is_null' },
+      { type: 'condition', column: 'status', op: 'is_not_null' },
+    ],
+  }, cols);
+  assert.equal(sql, ' WHERE ("name" IS NULL AND "status" IS NOT NULL)');
+  assert.deepEqual(params, []);
+});
+
+test('IN / NIN use ANY/ALL with the array as one parameter', () => {
+  const { sql, params } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [
+      { type: 'condition', column: 'status', op: 'in', value: ['a', 'b'] },
+      { type: 'condition', column: 'id', op: 'nin', value: [1, 2] },
+    ],
+  }, cols);
+  assert.equal(sql, ' WHERE ("status" = ANY($1) AND "id" <> ALL($2))');
+  assert.deepEqual(params, [['a', 'b'], [1, 2]]);
+});
+
+test('IN rejects empty array', () => {
+  assert.throws(() => buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'status', op: 'in', value: [] }],
+  }, cols), /non-empty array/);
+});
+
+test('LIKE / ILIKE require string values', () => {
+  assert.throws(() => buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'name', op: 'like', value: 5 }],
+  }, cols), /string value/);
+});
+
+test('jsonb_contains adds ::jsonb cast and stringifies object values', () => {
+  const { sql, params } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'payload', op: 'jsonb_contains', value: { a: 1 } }],
+  }, cols);
+  assert.equal(sql, ' WHERE "payload" @> $1::jsonb');
+  assert.deepEqual(params, ['{"a":1}']);
+});
+
+test('jsonb_contains rejects non-jsonb columns', () => {
+  assert.throws(() => buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'name', op: 'jsonb_contains', value: { a: 1 } }],
+  }, cols), /json\/jsonb/);
+});
+
+test('array_overlaps emits && with array param', () => {
+  const { sql, params } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'tags', op: 'array_overlaps', value: ['x'] }],
+  }, cols);
+  assert.equal(sql, ' WHERE "tags" && $1');
+  assert.deepEqual(params, [['x']]);
+});
+
+test('unknown column is rejected', () => {
+  assert.throws(() => buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'nope', op: 'eq', value: 1 }],
+  }, cols), /Unknown column/);
+});
+
+test('unknown operator is rejected at parse', () => {
+  assert.throws(() => buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'id', op: 'between', value: 1 }],
+  }, cols), /Invalid filter spec/);
+});
+
+test('column name with embedded double quote is properly escaped', () => {
+  const oddCols = { 'we"ird': { dataType: 'text' } };
+  const { sql } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'we"ird', op: 'eq', value: 1 }],
+  }, oddCols);
+  assert.equal(sql, ' WHERE "we""ird" = $1');
+});
+
+test('depth limit is enforced', () => {
+  let node = { type: 'condition', column: 'id', op: 'eq', value: 1 };
+  for (let i = 0; i <= MAX_DEPTH + 1; i++) {
+    node = { type: 'group', combinator: 'and', children: [node] };
+  }
+  assert.throws(() => buildWhere(node, cols), /max depth/);
+});
+
+test('condition-count limit is enforced', () => {
+  const children = [];
+  for (let i = 0; i < MAX_CONDITIONS + 1; i++) {
+    children.push({ type: 'condition', column: 'id', op: 'eq', value: i });
+  }
+  assert.throws(
+    () => buildWhere({ type: 'group', combinator: 'and', children }, cols),
+    /max of/,
+  );
+});

--- a/test/unit/import.test.js
+++ b/test/unit/import.test.js
@@ -1,0 +1,148 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  IMPORT_MODES, buildImportStatement, batchSizeFor, coerceCell, columnCast,
+} = require('../../src/db/import');
+
+const META = {
+  id: { dataType: 'integer' },
+  name: { dataType: 'text' },
+  payload: { dataType: 'jsonb' },
+};
+const TABLE = '"public"."users"';
+
+function build(opts) {
+  return buildImportStatement({
+    qualifiedTable: TABLE,
+    targetColumns: ['id', 'name'],
+    columnMeta: META,
+    rows: [['1', 'Ann'], ['2', 'Bob']],
+    mode: 'insert',
+    ...opts,
+  });
+}
+
+// ---- coerceCell -------------------------------------------------------------
+
+test('coerceCell maps null/undefined to null', () => {
+  assert.equal(coerceCell(null, true), null);
+  assert.equal(coerceCell(undefined, true), null);
+});
+
+test('coerceCell maps empty string to null only when emptyAsNull', () => {
+  assert.equal(coerceCell('', true), null);
+  assert.equal(coerceCell('', false), '');
+});
+
+test('coerceCell passes other values through unchanged', () => {
+  assert.equal(coerceCell('42', true), '42');
+  assert.equal(coerceCell('hello', false), 'hello');
+});
+
+// ---- columnCast -------------------------------------------------------------
+
+test('columnCast casts only json/jsonb', () => {
+  assert.equal(columnCast({ dataType: 'jsonb' }), '::jsonb');
+  assert.equal(columnCast({ dataType: 'json' }), '::json');
+  assert.equal(columnCast({ dataType: 'integer' }), '');
+  assert.equal(columnCast(undefined), '');
+});
+
+// ---- buildImportStatement: shape -------------------------------------------
+
+test('builds a parameterized multi-row INSERT in column order', () => {
+  const { sql, params } = build();
+  assert.equal(
+    sql,
+    'INSERT INTO "public"."users" ("id", "name") VALUES ($1, $2), ($3, $4)' +
+    ' RETURNING (xmax = 0) AS pglens_inserted',
+  );
+  assert.deepEqual(params, ['1', 'Ann', '2', 'Bob']);
+});
+
+test('applies a jsonb cast on the placeholder for json columns', () => {
+  const { sql, params } = buildImportStatement({
+    qualifiedTable: TABLE,
+    targetColumns: ['id', 'payload'],
+    columnMeta: META,
+    rows: [['1', '{"a":1}']],
+    mode: 'insert',
+  });
+  assert.match(sql, /VALUES \(\$1, \$2::jsonb\)/);
+  assert.deepEqual(params, ['1', '{"a":1}']);
+});
+
+test('blank cells bind as NULL by default and as "" when emptyAsNull is false', () => {
+  assert.deepEqual(build({ rows: [['', 'x']] }).params, [null, 'x']);
+  assert.deepEqual(build({ rows: [['', 'x']], emptyAsNull: false }).params, ['', 'x']);
+});
+
+// ---- conflict modes ---------------------------------------------------------
+
+test('skip mode appends ON CONFLICT DO NOTHING', () => {
+  assert.match(build({ mode: 'skip' }).sql, /ON CONFLICT DO NOTHING RETURNING/);
+});
+
+test('update mode upserts non-key columns via EXCLUDED', () => {
+  const { sql } = build({ mode: 'update', conflictColumns: ['id'] });
+  assert.match(sql, /ON CONFLICT \("id"\) DO UPDATE SET "name" = EXCLUDED\."name"/);
+});
+
+test('update mode with only key columns degrades to DO NOTHING', () => {
+  const { sql } = buildImportStatement({
+    qualifiedTable: TABLE,
+    targetColumns: ['id'],
+    columnMeta: META,
+    rows: [['1']],
+    mode: 'update',
+    conflictColumns: ['id'],
+  });
+  assert.match(sql, /ON CONFLICT \("id"\) DO NOTHING/);
+});
+
+// ---- guards -----------------------------------------------------------------
+
+test('unknown mode throws', () => {
+  assert.throws(() => build({ mode: 'merge' }), /Unknown import mode/);
+});
+
+test('unknown target column throws', () => {
+  assert.throws(() => build({ targetColumns: ['id', 'ghost'] }), /Unknown column: ghost/);
+});
+
+test('duplicate target column throws', () => {
+  assert.throws(() => build({ targetColumns: ['id', 'id'] }), /Duplicate target column/);
+});
+
+test('a ragged row throws', () => {
+  assert.throws(() => build({ rows: [['1']] }), /expected 2/);
+});
+
+test('update mode without conflict columns throws', () => {
+  assert.throws(() => build({ mode: 'update' }), /requires at least one conflict column/);
+});
+
+test('a conflict column outside the mapping throws', () => {
+  assert.throws(
+    () => build({ mode: 'update', conflictColumns: ['name', 'missing'] }),
+    /must be one of the mapped columns/,
+  );
+});
+
+test('empty rows throws', () => {
+  assert.throws(() => build({ rows: [] }), /No rows to import/);
+});
+
+// ---- batchSizeFor -----------------------------------------------------------
+
+test('batchSizeFor keeps rows*columns under the 65535 param cap', () => {
+  assert.equal(batchSizeFor(1), 65535);
+  assert.equal(batchSizeFor(10), 6553);
+  assert.ok(batchSizeFor(10) * 10 <= 65535);
+  assert.equal(batchSizeFor(0), 1);
+});
+
+test('IMPORT_MODES lists the three wizard modes', () => {
+  assert.deepEqual(IMPORT_MODES, ['insert', 'skip', 'update']);
+});

--- a/test/unit/insert.test.js
+++ b/test/unit/insert.test.js
@@ -1,0 +1,118 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildInsertRow } = require('../../src/db/insert');
+
+const cols = {
+  id: { dataType: 'integer', isPrimaryKey: true, isForeignKey: false, foreignKeyRef: null, isUnique: true, isNullable: false, hasDefault: true },
+  name: { dataType: 'text', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false, isNullable: true, hasDefault: false },
+  status: { dataType: 'text', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false, isNullable: false, hasDefault: true },
+  payload: { dataType: 'jsonb', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false, isNullable: true, hasDefault: false },
+};
+
+test('builds a parameterized INSERT with the supplied columns', () => {
+  const { sql, params } = buildInsertRow(
+    { values: { name: 'bob', status: 'active' } },
+    cols,
+    '"public"."users"',
+  );
+  assert.equal(
+    sql,
+    'INSERT INTO "public"."users" ("name", "status") VALUES ($1, $2) RETURNING *',
+  );
+  assert.deepEqual(params, ['bob', 'active']);
+});
+
+test('omitted columns are simply absent so the DB applies their DEFAULT', () => {
+  const { sql, params } = buildInsertRow(
+    { values: { name: 'bob' } },
+    cols,
+    '"public"."users"',
+  );
+  // `id` and `status` (both default-having) are not in the column list.
+  assert.equal(sql, 'INSERT INTO "public"."users" ("name") VALUES ($1) RETURNING *');
+  assert.deepEqual(params, ['bob']);
+});
+
+test('empty values emit DEFAULT VALUES', () => {
+  const { sql, params } = buildInsertRow({ values: {} }, cols, '"public"."t"');
+  assert.equal(sql, 'INSERT INTO "public"."t" DEFAULT VALUES RETURNING *');
+  assert.deepEqual(params, []);
+});
+
+test('jsonb objects are stringified and cast to ::jsonb', () => {
+  const { sql, params } = buildInsertRow(
+    { values: { payload: { a: 1 } } },
+    cols,
+    '"public"."t"',
+  );
+  assert.equal(sql, 'INSERT INTO "public"."t" ("payload") VALUES ($1::jsonb) RETURNING *');
+  assert.deepEqual(params, ['{"a":1}']);
+});
+
+test('jsonb null does NOT get the cast (so the column is set to SQL NULL)', () => {
+  const { sql, params } = buildInsertRow(
+    { values: { payload: null } },
+    cols,
+    '"public"."t"',
+  );
+  assert.equal(sql, 'INSERT INTO "public"."t" ("payload") VALUES ($1) RETURNING *');
+  assert.deepEqual(params, [null]);
+});
+
+test('explicit NULL is preserved for a regular column', () => {
+  const { sql, params } = buildInsertRow(
+    { values: { name: null } },
+    cols,
+    '"public"."t"',
+  );
+  assert.equal(sql, 'INSERT INTO "public"."t" ("name") VALUES ($1) RETURNING *');
+  assert.deepEqual(params, [null]);
+});
+
+test('unknown column is rejected', () => {
+  assert.throws(
+    () => buildInsertRow({ values: { nope: 1 } }, cols, '"public"."t"'),
+    /Unknown column/,
+  );
+});
+
+test('non-object values is rejected', () => {
+  assert.throws(
+    () => buildInsertRow({ values: [1, 2] }, cols, '"public"."t"'),
+    /`values` must be an object/,
+  );
+  assert.throws(
+    () => buildInsertRow({}, cols, '"public"."t"'),
+    /`values` must be an object/,
+  );
+});
+
+test('quoted identifiers handle special characters', () => {
+  const fancy = {
+    'col with spaces': { dataType: 'text', isPrimaryKey: false, isNullable: true, isForeignKey: false, foreignKeyRef: null, isUnique: false, hasDefault: false },
+    'Weird"Col': { dataType: 'integer', isPrimaryKey: false, isNullable: true, isForeignKey: false, foreignKeyRef: null, isUnique: false, hasDefault: false },
+  };
+  const { sql } = buildInsertRow(
+    { values: { 'col with spaces': 'v', 'Weird"Col': 3 } },
+    fancy,
+    '"s"."t"',
+  );
+  assert.equal(
+    sql,
+    'INSERT INTO "s"."t" ("col with spaces", "Weird""Col") VALUES ($1, $2) RETURNING *',
+  );
+});
+
+test('multiple jsonb/regular params get sequential placeholders', () => {
+  const { sql, params } = buildInsertRow(
+    { values: { name: 'x', payload: { k: 'v' }, status: 'on' } },
+    cols,
+    '"public"."t"',
+  );
+  assert.equal(
+    sql,
+    'INSERT INTO "public"."t" ("name", "payload", "status") VALUES ($1, $2::jsonb, $3) RETURNING *',
+  );
+  assert.deepEqual(params, ['x', '{"k":"v"}', 'on']);
+});

--- a/test/unit/sort.test.js
+++ b/test/unit/sort.test.js
@@ -1,0 +1,110 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildOrderBy, MAX_SORTS } = require('../../src/db/sort');
+
+const cols = {
+  id:      { dataType: 'integer', isPrimaryKey: true,  isForeignKey: false, foreignKeyRef: null, isUnique: true },
+  name:    { dataType: 'text',    isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false },
+  created: { dataType: 'timestamp', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false },
+  status:  { dataType: 'text',    isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false },
+};
+
+test('buildOrderBy returns empty when spec is null and no PK', () => {
+  assert.deepEqual(buildOrderBy(null, cols, null), { sql: '', columns: [] });
+});
+
+test('buildOrderBy emits PK tie-break when spec is empty and PK exists', () => {
+  const { sql, columns } = buildOrderBy(null, cols, 'id');
+  assert.equal(sql, ' ORDER BY "id" ASC');
+  assert.deepEqual(columns, []);
+});
+
+test('single column sort with PK tie-break appended', () => {
+  const { sql, columns } = buildOrderBy(
+    [{ column: 'name', direction: 'asc' }], cols, 'id',
+  );
+  assert.equal(sql, ' ORDER BY "name" ASC, "id" ASC');
+  assert.deepEqual(columns, ['name']);
+});
+
+test('PK already in user sort: not duplicated as tie-break', () => {
+  const { sql } = buildOrderBy(
+    [{ column: 'id', direction: 'desc' }], cols, 'id',
+  );
+  assert.equal(sql, ' ORDER BY "id" DESC');
+});
+
+test('multi-column sort preserves priority order', () => {
+  const { sql, columns } = buildOrderBy([
+    { column: 'status', direction: 'asc' },
+    { column: 'created', direction: 'desc' },
+    { column: 'name', direction: 'asc' },
+  ], cols, 'id');
+  assert.equal(sql, ' ORDER BY "status" ASC, "created" DESC, "name" ASC, "id" ASC');
+  assert.deepEqual(columns, ['status', 'created', 'name']);
+});
+
+test('lowercase direction normalized to uppercase in SQL', () => {
+  const { sql } = buildOrderBy(
+    [{ column: 'name', direction: 'desc' }], cols, null,
+  );
+  assert.equal(sql, ' ORDER BY "name" DESC');
+});
+
+test('uppercase direction accepted', () => {
+  const { sql } = buildOrderBy(
+    [{ column: 'name', direction: 'ASC' }], cols, null,
+  );
+  assert.equal(sql, ' ORDER BY "name" ASC');
+});
+
+test('unknown column throws', () => {
+  assert.throws(
+    () => buildOrderBy([{ column: 'nope', direction: 'asc' }], cols),
+    /Unknown sort column: nope/,
+  );
+});
+
+test('invalid direction throws via schema', () => {
+  assert.throws(
+    () => buildOrderBy([{ column: 'name', direction: 'sideways' }], cols),
+    /Invalid sort spec/,
+  );
+});
+
+test('duplicate column entries deduped, first occurrence kept', () => {
+  const { sql, columns } = buildOrderBy([
+    { column: 'name', direction: 'asc' },
+    { column: 'name', direction: 'desc' },
+  ], cols, null);
+  assert.equal(sql, ' ORDER BY "name" ASC');
+  assert.deepEqual(columns, ['name']);
+});
+
+test('exceeding MAX_SORTS throws', () => {
+  const entries = Array.from({ length: MAX_SORTS + 1 }, (_, i) => ({
+    column: 'name', direction: 'asc',
+  }));
+  assert.throws(
+    () => buildOrderBy(entries, cols),
+    /Invalid sort spec/,
+  );
+});
+
+test('null-byte column name rejected', () => {
+  assert.throws(
+    () => buildOrderBy([{ column: 'n\0ame', direction: 'asc' }], cols),
+    /Invalid sort spec/,
+  );
+});
+
+test('identifiers with embedded quotes are escaped', () => {
+  const quoted = {
+    'evil"name': { dataType: 'text', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false },
+  };
+  const { sql } = buildOrderBy(
+    [{ column: 'evil"name', direction: 'asc' }], quoted, null,
+  );
+  assert.equal(sql, ' ORDER BY "evil""name" ASC');
+});

--- a/test/unit/update.test.js
+++ b/test/unit/update.test.js
@@ -1,0 +1,136 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildUpdateRow } = require('../../src/db/update');
+
+const cols = {
+  id: { dataType: 'integer', isPrimaryKey: true, isForeignKey: false, foreignKeyRef: null, isUnique: true, isNullable: false },
+  name: { dataType: 'text', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false, isNullable: true },
+  status: { dataType: 'text', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false, isNullable: true },
+  payload: { dataType: 'jsonb', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false, isNullable: true },
+};
+
+const compositeCols = {
+  tenant_id: { dataType: 'uuid', isPrimaryKey: true, isForeignKey: false, foreignKeyRef: null, isUnique: false, isNullable: false },
+  id: { dataType: 'integer', isPrimaryKey: true, isForeignKey: false, foreignKeyRef: null, isUnique: false, isNullable: false },
+  name: { dataType: 'text', isPrimaryKey: false, isForeignKey: false, foreignKeyRef: null, isUnique: false, isNullable: true },
+};
+
+test('builds a parameterized UPDATE with single-column PK', () => {
+  const { sql, params } = buildUpdateRow(
+    { where: { id: 7 }, set: { name: 'bob', status: 'active' } },
+    cols,
+    '"public"."users"',
+  );
+  assert.equal(
+    sql,
+    'UPDATE "public"."users" SET "name" = $1, "status" = $2 WHERE "id" = $3 RETURNING *',
+  );
+  assert.deepEqual(params, ['bob', 'active', 7]);
+});
+
+test('jsonb objects are stringified and cast to ::jsonb', () => {
+  const { sql, params } = buildUpdateRow(
+    { where: { id: 1 }, set: { payload: { a: 1 } } },
+    cols,
+    '"public"."t"',
+  );
+  assert.equal(sql, 'UPDATE "public"."t" SET "payload" = $1::jsonb WHERE "id" = $2 RETURNING *');
+  assert.deepEqual(params, ['{"a":1}', 1]);
+});
+
+test('jsonb null does NOT get the cast (so the column is set to SQL NULL)', () => {
+  const { sql, params } = buildUpdateRow(
+    { where: { id: 1 }, set: { payload: null } },
+    cols,
+    '"public"."t"',
+  );
+  assert.equal(sql, 'UPDATE "public"."t" SET "payload" = $1 WHERE "id" = $2 RETURNING *');
+  assert.deepEqual(params, [null, 1]);
+});
+
+test('composite PK requires every key in where', () => {
+  assert.throws(
+    () =>
+      buildUpdateRow(
+        { where: { id: 5 }, set: { name: 'x' } },
+        compositeCols,
+        '"public"."t"',
+      ),
+    /every primary-key column/,
+  );
+});
+
+test('non-PK key in where is rejected', () => {
+  assert.throws(
+    () =>
+      buildUpdateRow(
+        { where: { id: 1, name: 'x' }, set: { status: 'y' } },
+        cols,
+        '"public"."t"',
+      ),
+    /only accepts primary-key columns/,
+  );
+});
+
+test('unknown column in set is rejected', () => {
+  assert.throws(
+    () =>
+      buildUpdateRow(
+        { where: { id: 1 }, set: { nope: 1 } },
+        cols,
+        '"public"."t"',
+      ),
+    /Unknown column/,
+  );
+});
+
+test('empty set is rejected', () => {
+  assert.throws(
+    () =>
+      buildUpdateRow({ where: { id: 1 }, set: {} }, cols, '"public"."t"'),
+    /at least one column/,
+  );
+});
+
+test('table with no PK is rejected', () => {
+  const noPk = { ...cols };
+  noPk.id = { ...cols.id, isPrimaryKey: false };
+  assert.throws(
+    () =>
+      buildUpdateRow({ where: { id: 1 }, set: { name: 'x' } }, noPk, '"public"."t"'),
+    /no primary key/,
+  );
+});
+
+test('composite PK happy path emits both keys in WHERE', () => {
+  const { sql, params } = buildUpdateRow(
+    {
+      where: { id: 5, tenant_id: '11111111-1111-1111-1111-111111111111' },
+      set: { name: 'x' },
+    },
+    compositeCols,
+    '"public"."t"',
+  );
+  assert.equal(
+    sql,
+    'UPDATE "public"."t" SET "name" = $1 WHERE "tenant_id" = $2 AND "id" = $3 RETURNING *',
+  );
+  assert.deepEqual(params, ['x', '11111111-1111-1111-1111-111111111111', 5]);
+});
+
+test('quoted identifiers handle special characters', () => {
+  const fancy = {
+    'Id"With"Quotes': { dataType: 'integer', isPrimaryKey: true, isNullable: false, isForeignKey: false, foreignKeyRef: null, isUnique: false },
+    'col with spaces': { dataType: 'text', isPrimaryKey: false, isNullable: true, isForeignKey: false, foreignKeyRef: null, isUnique: false },
+  };
+  const { sql } = buildUpdateRow(
+    { where: { 'Id"With"Quotes': 1 }, set: { 'col with spaces': 'v' } },
+    fancy,
+    '"s"."t"',
+  );
+  assert.equal(
+    sql,
+    'UPDATE "s"."t" SET "col with spaces" = $1 WHERE "Id""With""Quotes" = $2 RETURNING *',
+  );
+});

--- a/test/unit/views.test.js
+++ b/test/unit/views.test.js
@@ -1,0 +1,154 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Each test needs its own HOME so the views.json file doesn't bleed between
+// runs (the store caches in-process, and the on-disk file is keyed off HOME
+// via src/config/paths.js).
+function sandbox() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pglens-views-'));
+  process.env.HOME = dir;
+  return dir;
+}
+
+function freshStore() {
+  // Re-require both modules so the new HOME drives VIEWS_FILE and the
+  // in-memory cache is empty.
+  delete require.cache[require.resolve('../../src/config/paths')];
+  delete require.cache[require.resolve('../../src/db/views')];
+  return require('../../src/db/views');
+}
+
+test('listViews returns empty when no file exists', () => {
+  sandbox();
+  const views = freshStore();
+  assert.deepEqual(views.listViews(), []);
+});
+
+test('createView assigns id + timestamps and persists', () => {
+  const dir = sandbox();
+  const views = freshStore();
+  const v = views.createView({
+    connectionId: 'conn1',
+    tableName: 'orders',
+    name: 'Open orders',
+    filter: {
+      type: 'group',
+      combinator: 'and',
+      children: [{ type: 'condition', column: 'status', op: 'eq', value: 'open' }],
+    },
+    sort: [{ column: 'created_at', direction: 'desc' }],
+  });
+  assert.match(v.id, /^[0-9a-f-]{36}$/);
+  assert.ok(v.createdAt);
+  assert.ok(v.updatedAt);
+
+  // Persisted to disk.
+  const raw = JSON.parse(fs.readFileSync(path.join(dir, '.pglens/views.json'), 'utf8'));
+  assert.equal(raw.views.length, 1);
+  assert.equal(raw.views[0].name, 'Open orders');
+});
+
+test('createView blocks duplicate name within (connection, table)', () => {
+  sandbox();
+  const views = freshStore();
+  views.createView({ connectionId: 'c', tableName: 't', name: 'A' });
+  assert.throws(
+    () => views.createView({ connectionId: 'c', tableName: 't', name: 'A' }),
+    /already exists/,
+  );
+  // Same name, different table — allowed.
+  assert.doesNotThrow(() =>
+    views.createView({ connectionId: 'c', tableName: 'other', name: 'A' }),
+  );
+});
+
+test('listViews filters by connectionId + tableName', () => {
+  sandbox();
+  const views = freshStore();
+  views.createView({ connectionId: 'c1', tableName: 't1', name: 'a' });
+  views.createView({ connectionId: 'c1', tableName: 't2', name: 'b' });
+  views.createView({ connectionId: 'c2', tableName: 't1', name: 'c' });
+  assert.equal(views.listViews({ connectionId: 'c1' }).length, 2);
+  assert.equal(views.listViews({ connectionId: 'c1', tableName: 't1' }).length, 1);
+  assert.equal(views.listViews({}).length, 3);
+});
+
+test('updateView rewrites the on-disk file and bumps updatedAt', async () => {
+  sandbox();
+  const views = freshStore();
+  const v = views.createView({ connectionId: 'c', tableName: 't', name: 'A' });
+  // Ensure the timestamp resolution flips.
+  await new Promise((r) => setTimeout(r, 10));
+  const updated = views.updateView(v.id, { name: 'A2' });
+  assert.equal(updated.name, 'A2');
+  assert.notEqual(updated.updatedAt, v.updatedAt);
+  assert.equal(updated.createdAt, v.createdAt);
+});
+
+test('updateView blocks rename onto a sibling name', () => {
+  sandbox();
+  const views = freshStore();
+  views.createView({ connectionId: 'c', tableName: 't', name: 'A' });
+  const b = views.createView({ connectionId: 'c', tableName: 't', name: 'B' });
+  assert.throws(() => views.updateView(b.id, { name: 'A' }), /already exists/);
+});
+
+test('updateView returns null for unknown id', () => {
+  sandbox();
+  const views = freshStore();
+  assert.equal(
+    views.updateView('00000000-0000-0000-0000-000000000000', { name: 'x' }),
+    null,
+  );
+});
+
+test('deleteView removes from store and disk', () => {
+  const dir = sandbox();
+  const views = freshStore();
+  const v = views.createView({ connectionId: 'c', tableName: 't', name: 'A' });
+  assert.equal(views.deleteView(v.id), true);
+  assert.equal(views.listViews().length, 0);
+  const raw = JSON.parse(fs.readFileSync(path.join(dir, '.pglens/views.json'), 'utf8'));
+  assert.equal(raw.views.length, 0);
+});
+
+test('deleteView returns false for unknown id', () => {
+  sandbox();
+  const views = freshStore();
+  assert.equal(
+    views.deleteView('00000000-0000-0000-0000-000000000000'),
+    false,
+  );
+});
+
+test('createView rejects empty name', () => {
+  sandbox();
+  const views = freshStore();
+  assert.throws(() =>
+    views.createView({ connectionId: 'c', tableName: 't', name: '' }),
+  );
+});
+
+test('createView rejects malformed filter', () => {
+  sandbox();
+  const views = freshStore();
+  assert.throws(() =>
+    views.createView({
+      connectionId: 'c',
+      tableName: 't',
+      name: 'bad',
+      filter: { type: 'group', combinator: 'xor', children: [] },
+    }),
+  );
+});
+
+test('store survives a corrupt views.json (resets to empty)', () => {
+  const dir = sandbox();
+  fs.mkdirSync(path.join(dir, '.pglens'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.pglens/views.json'), '{ not json');
+  const views = freshStore();
+  assert.deepEqual(views.listViews(), []);
+});


### PR DESCRIPTION
## v3.1.0 — Phase 1: No-Code Editing Core

Moves pglens from **viewer** to **client**. Every feature works without typing SQL; each no-code action has a "Show SQL" disclosure, and the UI never sends raw SQL fragments — the server parses structured specs into parameterized queries.

### Features (ROADMAP §4)
- **Visual filter builder** — type-aware operators (`=`, ranges, `LIKE`/`ILIKE`, `IN`, `IS NULL`, jsonb `@>`, array `&&`)
- **Visual multi-column sort** — drag-reorder chips + shift/cmd-click header sort, PK tie-break
- **Saved views** — filter + sort per `(connection, table)`, deep-linkable, atomic-write store
- **Type-aware inline editing** — `PATCH .../rows`, per-type widgets, optimistic + rollback
- **Row insert form** — `POST .../rows`, tri-state DEFAULT/NULL/value
- **FK click-through** — side panel, chained nav, jump-to-matching-rows
- **Per-column aggregations** — server-side against active filter
- **Per-table export** — streaming CSV/JSON/SQL, cursor + backpressure
- **CSV import wizard** — column mapping, `ON CONFLICT` modes, dry-run, transactional

### Also
- Neutral off-black dark mode
- Column metadata gains `udtName`/`isNullable`/`hasDefault` + raw default expr
- Global dump reuses shared `sqlLiteral()` (no drift); fix: connection store syncs resolved id

### Known limitation
- FK/enum columns degrade to text input until FK lookup pipeline lands

### Verification
- Backend 158/158 pass · Frontend typecheck clean, build OK, 25/25 pass · ROADMAP §4.10 DoD all 10 ship

Version `3.0.2` → `3.1.0`; CHANGELOG + README updated. Tag `v3.1.0` pushed.
