### PR TITLE
feat(operations): slow query view (roadmap §6.2)

### DIFF
--- a/client-next/src/components/Sidebar.tsx
+++ b/client-next/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import {
 } from '@tanstack/react-router'
 import {
   Activity, Bookmark, ChevronDown, ChevronRight, Download, Eye, GitBranch,
-  MoreVertical, Pencil, Plus, Power, Search, Table as TableIcon, Terminal,
+  MoreVertical, Pencil, Plus, Power, Search, Table as TableIcon, Terminal, Timer,
 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -314,6 +314,17 @@ export function Sidebar() {
           >
             <Activity className="h-3.5 w-3.5 text-muted-foreground" />
             Live activity
+          </Link>
+          <Link
+            to="/slow-queries"
+            onClick={() => openTab({ kind: 'slow-queries' })}
+            className={cn(
+              'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
+              !!matchRoute({ to: '/slow-queries' }) && 'bg-accent text-accent-foreground',
+            )}
+          >
+            <Timer className="h-3.5 w-3.5 text-muted-foreground" />
+            Slow queries
           </Link>
         </Section>
       )}

--- a/client-next/src/components/TabBar.tsx
+++ b/client-next/src/components/TabBar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
-import { X, Home, Table as TableIcon, Terminal, GitBranch, Activity } from 'lucide-react'
+import { X, Home, Table as TableIcon, Terminal, GitBranch, Activity, Timer } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Dialog } from '@/components/ui/dialog'
@@ -19,6 +19,7 @@ function routeToTab(pathname: string): Tab {
   if (pathname === '/query') return { kind: 'query' }
   if (pathname === '/schema') return { kind: 'schema' }
   if (pathname === '/operations') return { kind: 'operations' }
+  if (pathname === '/slow-queries') return { kind: 'slow-queries' }
   return { kind: 'home' }
 }
 
@@ -28,6 +29,7 @@ function tabIcon(t: Tab) {
     case 'query': return Terminal
     case 'schema': return GitBranch
     case 'operations': return Activity
+    case 'slow-queries': return Timer
     case 'home': return Home
   }
 }

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -1155,3 +1155,87 @@ export function cancelBackend(connectionId: string, pid: number) {
 export function terminateBackend(connectionId: string, pid: number) {
   return backendAction('terminate', connectionId, pid)
 }
+
+// ---- Slow query view (roadmap §6.2) -----------------------------------------
+
+// One pg_stat_statements aggregate. bigint counters (calls, rows, blocks)
+// arrive as strings; the float8 `*_exec_time` values (milliseconds) arrive as
+// numbers. `p95_exec_time_est` is derived server-side (mean + 1.6449·stddev,
+// clamped) since pg_stat_statements stores no true percentiles.
+const SlowStatementSchema = z.object({
+  queryid: z.string(),
+  query: z.string().nullable(),
+  calls: Numeric,
+  total_exec_time: Numeric,
+  mean_exec_time: Numeric,
+  stddev_exec_time: Numeric,
+  min_exec_time: Numeric,
+  max_exec_time: Numeric,
+  p95_exec_time_est: z.number().nullable(),
+  rows: Numeric,
+  shared_blks_hit: Numeric,
+  shared_blks_read: Numeric,
+  shared_blks_dirtied: Numeric.optional(),
+  shared_blks_written: Numeric,
+  local_blks_hit: Numeric.optional(),
+  local_blks_read: Numeric.optional(),
+  temp_blks_read: Numeric,
+  temp_blks_written: Numeric,
+})
+export type SlowStatement = z.infer<typeof SlowStatementSchema>
+
+// The list is a small state machine so the UI shows the enable prompt vs. the
+// table without parsing error strings — mirrors getStatements() server-side.
+const StatementsResponseSchema = z.object({
+  status: z.enum(['ready', 'not_installed', 'not_loaded']),
+  available: z.boolean(),
+  ddl: z.string().optional(),
+  statements: z.array(SlowStatementSchema),
+})
+export type StatementsResponse = z.infer<typeof StatementsResponseSchema>
+
+// Sortable metrics (roadmap §6.2). Mirrors the server-side allowlist.
+export type StatementSort = 'total_exec_time' | 'mean_exec_time' | 'calls'
+
+export function getSlowStatements(
+  connectionId: string,
+  sort: StatementSort,
+  limit?: number,
+  signal?: AbortSignal,
+) {
+  const params = new URLSearchParams({ sort })
+  if (limit) params.set('limit', String(limit))
+  return api(`/api/operations/statements?${params}`, StatementsResponseSchema, {
+    connectionId,
+    signal,
+  })
+}
+
+const StatementActionResponse = z.object({
+  reset: z.boolean().optional(),
+  enabled: z.boolean().optional(),
+  installed: z.boolean().optional(),
+  available: z.boolean().optional(),
+})
+export type StatementActionResult = z.infer<typeof StatementActionResponse>
+
+async function statementsAction(action: 'enable' | 'reset', connectionId: string) {
+  const res = await fetch(`/api/operations/statements/${action}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-connection-id': connectionId },
+    credentials: 'same-origin',
+  })
+  const json = await res.json().catch(() => null)
+  if (!res.ok) throw parseErrorBody(json, res.status)
+  return StatementActionResponse.parse(json)
+}
+
+/** Create pg_stat_statements (idempotent; needs a privileged role). */
+export function enableStatements(connectionId: string) {
+  return statementsAction('enable', connectionId)
+}
+
+/** Discard all collected statistics (roadmap §6.2: "Reset stats"). */
+export function resetStatements(connectionId: string) {
+  return statementsAction('reset', connectionId)
+}

--- a/client-next/src/lib/explainSql.ts
+++ b/client-next/src/lib/explainSql.ts
@@ -1,0 +1,22 @@
+/**
+ * Build the SQL handed to the Query editor by the slow-query drilldown's
+ * "Explain in editor" action (roadmap §6.2).
+ *
+ * pg_stat_statements stores *normalized* query text — every literal is replaced
+ * by a placeholder (`$1`, `$2`, …). A plain `EXPLAIN` on that fails with
+ * "there is no parameter $1", because the placeholders have no bound values.
+ *
+ * `EXPLAIN (GENERIC_PLAN)` (PostgreSQL 16+) is built for exactly this: it plans
+ * a parameterized statement without any parameter values, treating the
+ * placeholders as unknown. So the normalized text runs as-is. Statements with
+ * no placeholders get a plain `EXPLAIN`.
+ */
+export function buildExplainSql(query: string): string {
+  const sql = query.trim()
+  if (!/\$\d+/.test(sql)) return `EXPLAIN\n${sql}`
+  return (
+    '-- pg_stat_statements normalized literals to $1, $2…; GENERIC_PLAN plans the\n' +
+    '-- parameterized form without values (PostgreSQL 16+).\n' +
+    `EXPLAIN (GENERIC_PLAN)\n${sql}`
+  )
+}

--- a/client-next/src/lib/format.ts
+++ b/client-next/src/lib/format.ts
@@ -1,0 +1,69 @@
+/**
+ * Display formatters for the Operations surfaces (roadmap §6.1, §6.2).
+ *
+ * Postgres bigint/numeric values arrive as strings through the driver while
+ * int4/float8 arrive as numbers; every formatter accepts either and renders an
+ * em-dash for null/unparseable input rather than "NaN".
+ */
+
+/** Coerce a driver value (number | numeric-string | null) to a finite number, or null. */
+export function toNum(v: number | string | null | undefined): number | null {
+  if (v == null) return null
+  const n = typeof v === 'number' ? v : Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+/** Human byte size (1024-based): "4.0 KB", "1.2 GB". */
+export function formatBytes(v: number | string | null | undefined): string {
+  const n = toNum(v)
+  if (n == null) return '—'
+  if (n < 1024) return `${n} B`
+  const units = ['KB', 'MB', 'GB', 'TB', 'PB']
+  let val = n / 1024
+  let i = 0
+  while (val >= 1024 && i < units.length - 1) {
+    val /= 1024
+    i++
+  }
+  return `${val.toFixed(val >= 10 ? 0 : 1)} ${units[i]}`
+}
+
+/** Coarse duration from seconds: "<1s", "45s", "3m 20s", "2h 5m". */
+export function formatDuration(v: number | string | null | undefined): string {
+  const s = toNum(v)
+  if (s == null) return '—'
+  if (s < 1) return '<1s'
+  const sec = Math.floor(s)
+  const h = Math.floor(sec / 3600)
+  const m = Math.floor((sec % 3600) / 60)
+  const r = sec % 60
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m ${r}s`
+  return `${r}s`
+}
+
+/** Execution time given in milliseconds: "0.4 ms", "12 ms", "1.5 s", "2.3 min". */
+export function formatMs(v: number | string | null | undefined): string {
+  const ms = toNum(v)
+  if (ms == null) return '—'
+  if (ms < 1) return `${ms.toFixed(2)} ms`
+  if (ms < 1000) return `${ms.toFixed(ms < 10 ? 1 : 0)} ms`
+  const s = ms / 1000
+  if (s < 60) return `${s.toFixed(s < 10 ? 2 : 1)} s`
+  return `${(s / 60).toFixed(1)} min`
+}
+
+/** Compact integer count: "942", "12.3K", "4.5M". */
+export function formatCount(v: number | string | null | undefined): string {
+  const n = toNum(v)
+  if (n == null) return '—'
+  if (n < 1000) return String(Math.round(n))
+  const units = ['K', 'M', 'B', 'T']
+  let val = n / 1000
+  let i = 0
+  while (val >= 1000 && i < units.length - 1) {
+    val /= 1000
+    i++
+  }
+  return `${val.toFixed(val >= 10 ? 0 : 1)}${units[i]}`
+}

--- a/client-next/src/pages/Operations.tsx
+++ b/client-next/src/pages/Operations.tsx
@@ -14,6 +14,7 @@ import {
   type DatabaseSize, type OpsSection, type ReplicationEntry, type TableSize,
 } from '@/lib/api'
 import { cn } from '@/lib/utils'
+import { formatBytes, formatDuration } from '@/lib/format'
 import { useConnectionStore } from '@/store/connection'
 
 // Roadmap §6.1: "Refresh every 5 seconds while the panel is open."
@@ -537,37 +538,4 @@ function Th({ children, className }: { children: React.ReactNode; className?: st
 
 function Td({ children, className, title }: { children: React.ReactNode; className?: string; title?: string }) {
   return <td className={cn('px-3 py-1.5', className)} title={title}>{children}</td>
-}
-
-function toNum(v: number | string | null | undefined): number | null {
-  if (v == null) return null
-  const n = typeof v === 'number' ? v : Number(v)
-  return Number.isFinite(n) ? n : null
-}
-
-function formatBytes(v: number | string | null | undefined): string {
-  const n = toNum(v)
-  if (n == null) return '—'
-  if (n < 1024) return `${n} B`
-  const units = ['KB', 'MB', 'GB', 'TB', 'PB']
-  let val = n / 1024
-  let i = 0
-  while (val >= 1024 && i < units.length - 1) {
-    val /= 1024
-    i++
-  }
-  return `${val.toFixed(val >= 10 ? 0 : 1)} ${units[i]}`
-}
-
-function formatDuration(v: number | string | null | undefined): string {
-  const s = toNum(v)
-  if (s == null) return '—'
-  if (s < 1) return '<1s'
-  const sec = Math.floor(s)
-  const h = Math.floor(sec / 3600)
-  const m = Math.floor((sec % 3600) / 60)
-  const r = sec % 60
-  if (h > 0) return `${h}h ${m}m`
-  if (m > 0) return `${m}m ${r}s`
-  return `${r}s`
 }

--- a/client-next/src/pages/QueryRunner.tsx
+++ b/client-next/src/pages/QueryRunner.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { SqlConsole } from '@/components/SqlConsole'
 import { useConnectionStore } from '@/store/connection'
+import { useQuerySeedStore } from '@/store/querySeed'
 
 const DEFAULT_SQL = `-- Advanced mode. Raw SQL escape hatch.
 -- Press Cmd/Ctrl + Enter to run.
@@ -11,6 +12,18 @@ SELECT now();`
 export function QueryRunner() {
   const connectionId = useConnectionStore((s) => s.activeConnectionId)
   const [sql, setSql] = useState(DEFAULT_SQL)
+
+  // Apply a one-shot seed handed in from elsewhere (e.g. the slow-query
+  // drilldown's "Explain" action), then clear it so it doesn't reapply. Works
+  // whether this tab was just opened or was already mounted.
+  const seed = useQuerySeedStore((s) => s.seed)
+  const clearSeed = useQuerySeedStore((s) => s.clear)
+  useEffect(() => {
+    if (seed != null) {
+      setSql(seed)
+      clearSeed()
+    }
+  }, [seed, clearSeed])
 
   if (!connectionId) {
     return (

--- a/client-next/src/pages/SlowQueries.tsx
+++ b/client-next/src/pages/SlowQueries.tsx
@@ -1,0 +1,444 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import {
+  ChevronDown, ChevronRight, Copy, Database, Play, RefreshCw, RotateCcw,
+} from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Dialog } from '@/components/ui/dialog'
+import { Select } from '@/components/ui/select'
+import { Loading, Spinner } from '@/components/ui/spinner'
+import {
+  enableStatements, getSlowStatements, resetStatements,
+  type SlowStatement, type StatementsResponse, type StatementSort,
+} from '@/lib/api'
+import { buildExplainSql } from '@/lib/explainSql'
+import { formatBytes, formatCount, formatMs, toNum } from '@/lib/format'
+import { cn } from '@/lib/utils'
+import { useConnectionStore } from '@/store/connection'
+import { useQuerySeedStore } from '@/store/querySeed'
+import { useTabsStore } from '@/store/tabs'
+
+// pg_stat_statements counts IO in blocks; convert to bytes for display using
+// the default block size (BLCKSZ). Non-default builds are rare and only skew
+// the human-readable size, never the block counts themselves.
+const BLOCK_BYTES = 8192
+
+const SORTS: { value: StatementSort; label: string }[] = [
+  { value: 'total_exec_time', label: 'Total time' },
+  { value: 'mean_exec_time', label: 'Mean time' },
+  { value: 'calls', label: 'Calls' },
+]
+
+export function SlowQueries() {
+  const connectionId = useConnectionStore((s) => s.activeConnectionId)
+  const qc = useQueryClient()
+  const [sort, setSort] = useState<StatementSort>('total_exec_time')
+  const [confirmReset, setConfirmReset] = useState(false)
+
+  const stmts = useQuery({
+    queryKey: ['slow-queries', connectionId, sort],
+    queryFn: ({ signal }) => getSlowStatements(connectionId!, sort, undefined, signal),
+    enabled: !!connectionId,
+    placeholderData: (prev) => prev,
+  })
+
+  const enableMut = useMutation({
+    mutationFn: () => enableStatements(connectionId!),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['slow-queries', connectionId] }),
+  })
+
+  const resetMut = useMutation({
+    mutationFn: () => resetStatements(connectionId!),
+    onSuccess: () => {
+      setConfirmReset(false)
+      qc.invalidateQueries({ queryKey: ['slow-queries', connectionId] })
+    },
+  })
+
+  if (!connectionId) {
+    return (
+      <div className="px-10 py-10 text-sm text-muted-foreground">
+        No active connection.
+      </div>
+    )
+  }
+
+  const data = stmts.data
+  const ready = data?.status === 'ready'
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="flex items-center justify-between border-b border-border px-6 py-3">
+        <div>
+          <h1 className="text-lg font-semibold">Slow queries</h1>
+          <p className="text-xs text-muted-foreground">
+            Aggregated by <code className="font-mono">pg_stat_statements</code>
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {ready && (
+            <>
+              <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                Sort by
+                <Select
+                  className="w-36"
+                  value={sort}
+                  onChange={(e) => setSort(e.target.value as StatementSort)}
+                >
+                  {SORTS.map((s) => (
+                    <option key={s.value} value={s.value}>{s.label}</option>
+                  ))}
+                </Select>
+              </label>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => stmts.refetch()}
+                disabled={stmts.isFetching}
+                title="Refresh"
+              >
+                {stmts.isFetching ? <Spinner aria-label="Refreshing" /> : <RefreshCw className="h-3.5 w-3.5" />}
+                Refresh
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setConfirmReset(true)}
+                title="Discard all collected statistics"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+                Reset stats
+              </Button>
+            </>
+          )}
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-auto px-6 py-4">
+        {stmts.isLoading && (
+          <div className="py-10 text-center text-sm text-muted-foreground">
+            <Loading>Loading query statistics…</Loading>
+          </div>
+        )}
+
+        {stmts.error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {(stmts.error as Error).message}
+          </div>
+        )}
+
+        {data && data.status !== 'ready' && (
+          <EnablePrompt
+            response={data}
+            onEnable={() => enableMut.mutate()}
+            pending={enableMut.isPending}
+            error={enableMut.error ? (enableMut.error as Error).message : null}
+          />
+        )}
+
+        {ready && <StatementsTable statements={data.statements} />}
+      </div>
+
+      <ConfirmResetDialog
+        open={confirmReset}
+        pending={resetMut.isPending}
+        error={resetMut.error ? (resetMut.error as Error).message : null}
+        onConfirm={() => resetMut.mutate()}
+        onClose={() => {
+          if (!resetMut.isPending) {
+            resetMut.reset()
+            setConfirmReset(false)
+          }
+        }}
+      />
+    </div>
+  )
+}
+
+// ---- Enable / not-loaded prompt ---------------------------------------------
+
+function EnablePrompt({
+  response, onEnable, pending, error,
+}: {
+  response: StatementsResponse
+  onEnable: () => void
+  pending: boolean
+  error: string | null
+}) {
+  const notLoaded = response.status === 'not_loaded'
+  const unavailable = response.status === 'not_installed' && !response.available
+  return (
+    <div className="mx-auto max-w-2xl rounded-lg border border-border bg-card p-6">
+      <div className="flex items-start gap-3">
+        <Database className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold">
+            {notLoaded
+              ? 'pg_stat_statements is installed but not loaded'
+              : 'pg_stat_statements is not enabled'}
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {notLoaded ? (
+              <>
+                The extension is created, but its library isn’t in{' '}
+                <code className="font-mono">shared_preload_libraries</code>, so it
+                isn’t collecting yet. Add it and restart Postgres:
+              </>
+            ) : unavailable ? (
+              <>
+                This server doesn’t ship the <code className="font-mono">pg_stat_statements</code>{' '}
+                contrib module, so it can’t be enabled from here. Install the
+                Postgres contrib package on the server, then reload.
+              </>
+            ) : (
+              <>
+                This view needs the <code className="font-mono">pg_stat_statements</code>{' '}
+                extension. Enabling it runs:
+              </>
+            )}
+          </p>
+
+          {notLoaded ? (
+            <code className="mt-3 block rounded-md bg-muted px-3 py-2 font-mono text-xs">
+              # postgresql.conf{'\n'}shared_preload_libraries = 'pg_stat_statements'
+            </code>
+          ) : (
+            <code className="mt-3 block rounded-md bg-muted px-3 py-2 font-mono text-xs">
+              {response.ddl ?? 'CREATE EXTENSION IF NOT EXISTS pg_stat_statements;'}
+            </code>
+          )}
+
+          {!notLoaded && !unavailable && (
+            <>
+              <p className="mt-3 text-xs text-muted-foreground">
+                Requires a superuser. Collection also needs the library in{' '}
+                <code className="font-mono">shared_preload_libraries</code> (set
+                at install for most distributions).
+              </p>
+              <div className="mt-3 flex items-center gap-3">
+                <Button size="sm" onClick={onEnable} disabled={pending}>
+                  {pending && <Spinner aria-label="Enabling" />}
+                  Enable pg_stat_statements
+                </Button>
+                {error && <span className="text-xs text-destructive">{error}</span>}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---- Statements table -------------------------------------------------------
+
+function StatementsTable({ statements }: { statements: SlowStatement[] }) {
+  if (statements.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-muted-foreground">
+        No statements recorded yet. Run some queries, then refresh.
+      </p>
+    )
+  }
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <table className="w-full text-left text-xs">
+        <thead className="bg-card text-muted-foreground">
+          <tr className="border-b border-border">
+            <Th className="w-8" />
+            <Th>Query</Th>
+            <Th className="text-right">Calls</Th>
+            <Th className="text-right">Total</Th>
+            <Th className="text-right">Mean</Th>
+            <Th className="text-right" title="Estimated 95th percentile (mean + 1.64·stddev)">p95 est.</Th>
+            <Th className="text-right">Rows</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {statements.map((s) => (
+            <StatementRow key={s.queryid} stmt={s} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function StatementRow({ stmt }: { stmt: SlowStatement }) {
+  const [open, setOpen] = useState(false)
+  const query = stmt.query?.trim() || '—'
+  return (
+    <>
+      <tr
+        className="cursor-pointer border-b border-border/50 align-top hover:bg-accent/50"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <Td className="text-muted-foreground">
+          {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+        </Td>
+        <Td className="max-w-0">
+          <code className="block truncate font-mono text-[11px]" title={query}>{query}</code>
+        </Td>
+        <Td className="whitespace-nowrap text-right tabular-nums">{formatCount(stmt.calls)}</Td>
+        <Td className="whitespace-nowrap text-right tabular-nums font-medium">{formatMs(stmt.total_exec_time)}</Td>
+        <Td className="whitespace-nowrap text-right tabular-nums">{formatMs(stmt.mean_exec_time)}</Td>
+        <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">{formatMs(stmt.p95_exec_time_est)}</Td>
+        <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">{formatCount(stmt.rows)}</Td>
+      </tr>
+      {open && (
+        <tr className="border-b border-border/50 bg-muted/30">
+          <td />
+          <td colSpan={6} className="px-3 py-3">
+            <Drilldown stmt={stmt} />
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+function Drilldown({ stmt }: { stmt: SlowStatement }) {
+  const navigate = useNavigate()
+  const open = useTabsStore((s) => s.open)
+  const [copied, setCopied] = useState(false)
+  const query = stmt.query?.trim() ?? ''
+
+  // EXPLAIN integration (roadmap §6.2): hand the statement to the Query editor
+  // ready to run, where the §6.3 plan visualizer will plug in later.
+  const explain = () => {
+    useQuerySeedStore.getState().setSeed(buildExplainSql(query))
+    open({ kind: 'query' })
+    navigate({ to: '/query' })
+  }
+
+  const copy = () => {
+    void navigator.clipboard?.writeText(query).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  const cacheHit = cacheHitRatio(stmt.shared_blks_hit, stmt.shared_blks_read)
+
+  return (
+    <div className="space-y-3">
+      <code className="block max-h-48 overflow-auto whitespace-pre-wrap rounded-md bg-background px-3 py-2 font-mono text-[11px]">
+        {query || '—'}
+      </code>
+
+      <div className="grid grid-cols-2 gap-x-8 gap-y-3 sm:grid-cols-4">
+        <Metric label="Calls" value={formatCount(stmt.calls)} />
+        <Metric label="Total time" value={formatMs(stmt.total_exec_time)} />
+        <Metric label="Mean" value={formatMs(stmt.mean_exec_time)} />
+        <Metric label="Std dev" value={formatMs(stmt.stddev_exec_time)} />
+        <Metric label="Min" value={formatMs(stmt.min_exec_time)} />
+        <Metric label="p95 (est.)" value={formatMs(stmt.p95_exec_time_est)} hint="mean + 1.64·stddev" />
+        <Metric label="Max" value={formatMs(stmt.max_exec_time)} />
+        <Metric label="Rows / call" value={formatCount(perCall(stmt.rows, stmt.calls))} />
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-8 gap-y-3 sm:grid-cols-4">
+        <Metric label="Cache hit" value={cacheHit == null ? '—' : `${cacheHit.toFixed(1)}%`} />
+        <Metric label="Shared read" value={formatBytes(blocksToBytes(stmt.shared_blks_read))} />
+        <Metric label="Shared written" value={formatBytes(blocksToBytes(stmt.shared_blks_written))} />
+        <Metric label="Temp read / write" value={`${formatBytes(blocksToBytes(stmt.temp_blks_read))} / ${formatBytes(blocksToBytes(stmt.temp_blks_written))}`} />
+      </div>
+
+      <div className="flex items-center gap-2 pt-1">
+        <Button size="sm" variant="outline" onClick={explain} disabled={!query}>
+          <Play className="h-3.5 w-3.5" />
+          Explain in editor
+        </Button>
+        <Button size="sm" variant="ghost" onClick={copy} disabled={!query}>
+          <Copy className="h-3.5 w-3.5" />
+          {copied ? 'Copied' : 'Copy'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="flex flex-col" title={hint}>
+      <span className="text-[11px] text-muted-foreground">{label}</span>
+      <span className="text-sm font-medium tabular-nums">{value}</span>
+    </div>
+  )
+}
+
+// ---- Reset confirm ----------------------------------------------------------
+
+function ConfirmResetDialog({
+  open, pending, error, onConfirm, onClose,
+}: {
+  open: boolean
+  pending: boolean
+  error: string | null
+  onConfirm: () => void
+  onClose: () => void
+}) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Reset query statistics?"
+      footer={
+        <>
+          <Button variant="outline" size="sm" onClick={onClose} disabled={pending}>
+            Keep
+          </Button>
+          <Button variant="destructive" size="sm" onClick={onConfirm} disabled={pending}>
+            {pending && <Spinner aria-label="Resetting" />}
+            Reset stats
+          </Button>
+        </>
+      }
+    >
+      <p className="text-sm text-muted-foreground">
+        This runs{' '}
+        <code className="font-mono text-foreground">pg_stat_statements_reset()</code>,
+        discarding every recorded statement for the whole server. Stats start
+        accumulating again from zero.
+      </p>
+      {error && <p className="mt-3 text-xs text-destructive">{error}</p>}
+    </Dialog>
+  )
+}
+
+// ---- Small bits -------------------------------------------------------------
+
+function Th({ children, className, title }: { children?: React.ReactNode; className?: string; title?: string }) {
+  return <th className={cn('px-3 py-1.5 font-medium', className)} title={title}>{children}</th>
+}
+
+function Td({ children, className, title }: { children: React.ReactNode; className?: string; title?: string }) {
+  return <td className={cn('px-3 py-1.5', className)} title={title}>{children}</td>
+}
+
+function blocksToBytes(blocks: number | string | null | undefined): number | null {
+  const n = toNum(blocks)
+  return n == null ? null : n * BLOCK_BYTES
+}
+
+function cacheHitRatio(
+  hit: number | string | null | undefined,
+  read: number | string | null | undefined,
+): number | null {
+  const h = toNum(hit) ?? 0
+  const r = toNum(read) ?? 0
+  const total = h + r
+  return total === 0 ? null : (h / total) * 100
+}
+
+function perCall(
+  total: number | string | null | undefined,
+  calls: number | string | null | undefined,
+): number | null {
+  const t = toNum(total)
+  const c = toNum(calls)
+  if (t == null || c == null || c === 0) return null
+  return t / c
+}

--- a/client-next/src/routeTree.tsx
+++ b/client-next/src/routeTree.tsx
@@ -4,6 +4,7 @@ import { TableView } from './pages/TableView'
 import { SchemaViz } from './pages/SchemaViz'
 import { QueryRunner } from './pages/QueryRunner'
 import { Operations } from './pages/Operations'
+import { SlowQueries } from './pages/SlowQueries'
 import { Sidebar } from './components/Sidebar'
 import { TabBar } from './components/TabBar'
 import { Spotlight } from './components/Spotlight'
@@ -76,10 +77,17 @@ const operationsRoute = createRoute({
   component: Operations,
 })
 
+const slowQueriesRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/slow-queries',
+  component: SlowQueries,
+})
+
 export const routeTree = rootRoute.addChildren([
   homeRoute,
   tableRoute,
   schemaRoute,
   queryRoute,
   operationsRoute,
+  slowQueriesRoute,
 ])

--- a/client-next/src/store/querySeed.ts
+++ b/client-next/src/store/querySeed.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand'
+
+/**
+ * One-shot hand-off of SQL into the Query editor. The slow-query drilldown's
+ * "Explain" action (roadmap §6.2) sets a seed, opens the Query tab, and
+ * navigates there; the QueryRunner applies the seed and clears it. A store
+ * (rather than a route search param) keeps a potentially long, multi-line query
+ * out of the URL and applies even when the Query tab is already mounted.
+ */
+interface QuerySeedState {
+  seed: string | null
+  setSeed: (sql: string) => void
+  clear: () => void
+}
+
+export const useQuerySeedStore = create<QuerySeedState>()((set) => ({
+  seed: null,
+  setSeed: (sql) => set({ seed: sql }),
+  clear: () => set({ seed: null }),
+}))

--- a/client-next/src/store/tabs.ts
+++ b/client-next/src/store/tabs.ts
@@ -5,6 +5,7 @@ export type Tab =
   | { kind: 'query' }
   | { kind: 'schema' }
   | { kind: 'operations' }
+  | { kind: 'slow-queries' }
   | { kind: 'home' }
 
 function tabId(t: Tab): string {
@@ -13,6 +14,7 @@ function tabId(t: Tab): string {
     case 'query': return 'query'
     case 'schema': return 'schema'
     case 'operations': return 'operations'
+    case 'slow-queries': return 'slow-queries'
     case 'home': return 'home'
   }
 }
@@ -23,6 +25,7 @@ function tabLabel(t: Tab): string {
     case 'query': return 'Query'
     case 'schema': return 'Schema'
     case 'operations': return 'Operations'
+    case 'slow-queries': return 'Slow queries'
     case 'home': return 'Home'
   }
 }
@@ -33,6 +36,7 @@ function tabRoute(t: Tab): string {
     case 'query': return '/query'
     case 'schema': return '/schema'
     case 'operations': return '/operations'
+    case 'slow-queries': return '/slow-queries'
     case 'home': return '/'
   }
 }

--- a/client-next/test/unit/api.test.ts
+++ b/client-next/test/unit/api.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
-  ApiError, cancelBackend, exportTableData, getOperationsOverview,
-  importTableData, listConnections, runQuery, terminateBackend,
+  ApiError, cancelBackend, enableStatements, exportTableData,
+  getOperationsOverview, getSlowStatements, importTableData, listConnections,
+  resetStatements, runQuery, terminateBackend,
 } from '@/lib/api'
 import type { FilterGroup } from '@/lib/api'
 
@@ -339,5 +340,79 @@ describe('backend actions', () => {
       ),
     )
     await expect(terminateBackend('conn-1', 1)).rejects.toBeInstanceOf(ApiError)
+  })
+})
+
+describe('getSlowStatements', () => {
+  it('builds the sort/limit query, sends the connection header, parses rows', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        status: 'ready',
+        available: true,
+        statements: [
+          {
+            queryid: '123', query: 'SELECT * FROM users WHERE id = $1',
+            // bigint counters as strings, float8 times as numbers — both parse.
+            calls: '40', total_exec_time: 800, mean_exec_time: 20,
+            stddev_exec_time: 5, min_exec_time: 10, max_exec_time: 90,
+            p95_exec_time_est: 28.2, rows: '40',
+            shared_blks_hit: '1000', shared_blks_read: '12', shared_blks_written: '0',
+            temp_blks_read: '0', temp_blks_written: '0',
+          },
+        ],
+      }),
+    )
+    const result = await getSlowStatements('conn-1', 'mean_exec_time', 25)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/operations/statements?sort=mean_exec_time&limit=25')
+    expect(((init as RequestInit).headers as Record<string, string>)['x-connection-id']).toBe('conn-1')
+    expect(result.status).toBe('ready')
+    expect(result.statements[0]?.calls).toBe('40')
+    expect(result.statements[0]?.p95_exec_time_est).toBe(28.2)
+  })
+
+  it('parses the not_installed state with its enable DDL', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        status: 'not_installed',
+        available: true,
+        ddl: 'CREATE EXTENSION IF NOT EXISTS pg_stat_statements;',
+        statements: [],
+      }),
+    )
+    const result = await getSlowStatements('conn-1', 'total_exec_time')
+    expect(result.status).toBe('not_installed')
+    expect(result.ddl).toMatch(/CREATE EXTENSION/)
+    expect(result.statements).toEqual([])
+  })
+})
+
+describe('statement actions', () => {
+  it('enableStatements POSTs to the enable route with the connection header', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ enabled: true, installed: true, available: true }))
+    const result = await enableStatements('conn-1')
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/operations/statements/enable')
+    expect((init as RequestInit).method).toBe('POST')
+    expect(((init as RequestInit).headers as Record<string, string>)['x-connection-id']).toBe('conn-1')
+    expect(result.enabled).toBe(true)
+  })
+
+  it('resetStatements POSTs to the reset route', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ reset: true }))
+    const result = await resetStatements('conn-1')
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/operations/statements/reset')
+    expect(result.reset).toBe(true)
+  })
+
+  it('throws ApiError when the server rejects (e.g. not superuser)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        { error: { code: 'DB_ERROR', message: 'permission denied to create extension' } },
+        { status: 500 },
+      ),
+    )
+    await expect(enableStatements('conn-1')).rejects.toBeInstanceOf(ApiError)
   })
 })

--- a/client-next/test/unit/explainSql.test.ts
+++ b/client-next/test/unit/explainSql.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildExplainSql } from '@/lib/explainSql'
+
+describe('buildExplainSql', () => {
+  it('uses GENERIC_PLAN for a normalized (parameterized) statement', () => {
+    const out = buildExplainSql('SELECT * FROM users WHERE id = $1')
+    expect(out).toMatch(/EXPLAIN \(GENERIC_PLAN\)/)
+    expect(out).toContain('SELECT * FROM users WHERE id = $1')
+    // The original query body is preserved verbatim after the explain prefix.
+    expect(out.endsWith('SELECT * FROM users WHERE id = $1')).toBe(true)
+  })
+
+  it('detects placeholders anywhere, including DML with several params', () => {
+    const out = buildExplainSql('INSERT INTO t (a, b) VALUES ($1, $2) ON CONFLICT (a) DO UPDATE SET b = $2')
+    expect(out).toMatch(/EXPLAIN \(GENERIC_PLAN\)/)
+  })
+
+  it('uses a plain EXPLAIN when there are no placeholders', () => {
+    const out = buildExplainSql('SELECT now()')
+    expect(out).toBe('EXPLAIN\nSELECT now()')
+    expect(out).not.toMatch(/GENERIC_PLAN/)
+  })
+
+  it('does not treat a dollar-quoted body as a placeholder', () => {
+    // $$…$$ and $tag$ are dollar quoting, not parameters — plain EXPLAIN.
+    const out = buildExplainSql("SELECT $$literal $ text$$")
+    expect(out).not.toMatch(/GENERIC_PLAN/)
+  })
+
+  it('trims surrounding whitespace before building', () => {
+    expect(buildExplainSql('  SELECT 1  ')).toBe('EXPLAIN\nSELECT 1')
+  })
+})

--- a/src/config/paths.js
+++ b/src/config/paths.js
@@ -14,6 +14,9 @@ const CONNECTIONS_FILE = path.join(PGLENS_DIR, 'connections.json');
 const VIEWS_FILE = path.join(PGLENS_DIR, 'views.json');
 const SAVED_QUERIES_FILE = path.join(PGLENS_DIR, 'saved-queries.json');
 const QUERY_HISTORY_FILE = path.join(PGLENS_DIR, 'query-history.json');
+// Only used by the file-based secret store (PGLENS_SECRET_STORE=file); the
+// keychain backend stores nothing here.
+const SECRETS_FILE = path.join(PGLENS_DIR, 'secrets.json');
 const PID_FILE = path.join(os.homedir(), '.pglens.pid');
 const PORT_FILE = path.join(os.homedir(), '.pglens.port');
 
@@ -37,6 +40,7 @@ module.exports = {
   VIEWS_FILE,
   SAVED_QUERIES_FILE,
   QUERY_HISTORY_FILE,
+  SECRETS_FILE,
   PID_FILE,
   PORT_FILE,
   ensureDir,

--- a/src/db/secrets.js
+++ b/src/db/secrets.js
@@ -1,39 +1,108 @@
 /**
- * Keychain-backed secret storage for connection passwords.
+ * Secret storage for connection passwords.
  *
  * Service:   "pglens"
  * Account:   "<connection-id>"
  * Secret:    raw password string
  *
- * Uses `keytar` (macOS Keychain, Windows Credential Vault, libsecret on
- * Linux). On Linux without a Secret Service available, keytar throws on
- * setPassword; callers should surface that as a clear error.
+ * Default backend is the OS keychain via `keytar` (macOS Keychain, Windows
+ * Credential Vault, libsecret on Linux) — the Phase 0 hardening.
+ *
+ * Set `PGLENS_SECRET_STORE=file` to store secrets in `~/.pglens/secrets.json`
+ * (mode 0600) instead. Use this for tests, headless/CI runs, and machines
+ * whose keychain is unavailable or broken (e.g. macOS "A keychain cannot be
+ * found to store …"). If `keytar` can't even be loaded, we degrade to the
+ * file store with a warning rather than failing every /connect.
  */
 
-const keytar = require('keytar');
+const fs = require('fs');
 const logger = require('../log');
+const { SECRETS_FILE, ensureLayout } = require('../config/paths');
 
 const SERVICE = 'pglens';
 
+function createKeychainBackend() {
+  const keytar = require('keytar'); // native module — throws here if unloadable
+  return {
+    name: 'keychain',
+    set: (account, password) => keytar.setPassword(SERVICE, account, password),
+    get: (account) => keytar.getPassword(SERVICE, account),
+    del: (account) => keytar.deletePassword(SERVICE, account),
+  };
+}
+
+function createFileBackend() {
+  const readAll = () => {
+    try {
+      return JSON.parse(fs.readFileSync(SECRETS_FILE, 'utf8'));
+    } catch {
+      return {};
+    }
+  };
+  const writeAll = (map) => {
+    ensureLayout();
+    fs.writeFileSync(SECRETS_FILE, JSON.stringify(map), { mode: 0o600 });
+  };
+  return {
+    name: 'file',
+    set: async (account, password) => {
+      const map = readAll();
+      map[account] = password;
+      writeAll(map);
+    },
+    get: async (account) => {
+      const map = readAll();
+      return Object.prototype.hasOwnProperty.call(map, account) ? map[account] : null;
+    },
+    del: async (account) => {
+      const map = readAll();
+      if (Object.prototype.hasOwnProperty.call(map, account)) {
+        delete map[account];
+        writeAll(map);
+      }
+    },
+  };
+}
+
+let _backend;
+function backend() {
+  if (_backend) return _backend;
+  const choice = (process.env.PGLENS_SECRET_STORE || 'keychain').toLowerCase();
+  if (choice === 'file') {
+    _backend = createFileBackend();
+  } else {
+    try {
+      _backend = createKeychainBackend();
+    } catch (err) {
+      logger.warn(
+        { err: err.message },
+        'keytar unavailable; using file-based secret store (set PGLENS_SECRET_STORE=file to silence)'
+      );
+      _backend = createFileBackend();
+    }
+  }
+  return _backend;
+}
+
 async function setPassword(connectionId, password) {
   if (password == null || password === '') return;
-  await keytar.setPassword(SERVICE, connectionId, password);
+  await backend().set(connectionId, password);
 }
 
 async function getPassword(connectionId) {
   try {
-    return await keytar.getPassword(SERVICE, connectionId);
+    return await backend().get(connectionId);
   } catch (err) {
-    logger.warn({ err: err.message, connectionId }, 'keychain read failed');
+    logger.warn({ err: err.message, connectionId }, 'secret read failed');
     return null;
   }
 }
 
 async function deletePassword(connectionId) {
   try {
-    await keytar.deletePassword(SERVICE, connectionId);
+    await backend().del(connectionId);
   } catch (err) {
-    logger.warn({ err: err.message, connectionId }, 'keychain delete failed');
+    logger.warn({ err: err.message, connectionId }, 'secret delete failed');
   }
 }
 

--- a/src/db/slowQueries.js
+++ b/src/db/slowQueries.js
@@ -1,0 +1,193 @@
+/**
+ * Slow query view — Postgres-native operations (roadmap §6.2).
+ *
+ * Surfaces the server's own `pg_stat_statements` aggregates so a user can find
+ * the queries that cost the most cumulative time and drill into one for its
+ * timing spread and IO. Read-only except for the two explicit actions:
+ *
+ *   - enable → CREATE EXTENSION IF NOT EXISTS pg_stat_statements
+ *   - reset  → pg_stat_statements_reset()
+ *
+ * Like src/db/operations.js, every function takes the wrapped pool from
+ * `requireConnection` (req.pool) and runs parameterized queries against system
+ * views — no caller-supplied SQL ever reaches the server. The one column the
+ * caller influences is the ORDER BY, which is mapped through SORT_COLUMNS
+ * server-side (a fixed allowlist), never interpolated from raw input.
+ *
+ * Requires PostgreSQL 13+: the `*_exec_time` columns were renamed from the old
+ * `*_time` columns in pg_stat_statements 1.8 (PG13). Older servers surface the
+ * raw "column does not exist" error to the client.
+ */
+
+// CREATE EXTENSION is offered as a one-click action (roadmap §6.2: "show a
+// one-click 'Enable pg_stat_statements' with the DDL preview"). The same string
+// is shown to the user as the preview and run by the enable action.
+const ENABLE_DDL = 'CREATE EXTENSION IF NOT EXISTS pg_stat_statements;';
+
+// Allowlist of sortable metrics → the real column (roadmap §6.2: "Top queries
+// by total_exec_time, mean_exec_time, calls"). The ORDER BY is chosen from this
+// map only, so a bad/spoofed sort key can never reach the SQL.
+const SORT_COLUMNS = {
+  total_exec_time: 'total_exec_time',
+  mean_exec_time: 'mean_exec_time',
+  calls: 'calls',
+};
+const DEFAULT_SORT = 'total_exec_time';
+
+// Default / max rows returned. The view itself is capped by the server's
+// pg_stat_statements.max (default 5000); this just bounds the payload.
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+// One-sided 95th-percentile z-score of the standard normal. pg_stat_statements
+// stores only mean/stddev/min/max — not percentiles — so p95 is *estimated*
+// (see estimateP95). Kept in one place so the UI's "p95 (est.)" label and this
+// math never drift.
+const P95_Z = 1.6449;
+
+/**
+ * Estimate a query's 95th-percentile execution time from the only spread
+ * pg_stat_statements records: mean and stddev. Models the distribution as
+ * normal — p95 ≈ mean + 1.6449·stddev — then clamps to [mean, max] so the
+ * estimate never dips below the mean or exceeds the observed maximum. Pure, so
+ * the approximation lives in exactly one tested place. Returns null when the
+ * mean is unknown.
+ */
+function estimateP95(mean, stddev, max) {
+  if (mean == null) return null;
+  const m = Number(mean);
+  if (!Number.isFinite(m)) return null;
+  const sd = Number(stddev);
+  const est = Number.isFinite(sd) ? m + P95_Z * sd : m;
+  const floored = Math.max(est, m);
+  const cap = Number(max);
+  return Number.isFinite(cap) ? Math.min(floored, cap) : floored;
+}
+
+/** Map a (possibly untrusted) sort key to a real column, defaulting safely. */
+function sortColumn(key) {
+  return SORT_COLUMNS[key] ?? SORT_COLUMNS[DEFAULT_SORT];
+}
+
+/** Clamp the requested row limit into [1, MAX_LIMIT], defaulting when unset. */
+function rowLimit(limit) {
+  const n = Number(limit);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.floor(n), MAX_LIMIT);
+}
+
+/**
+ * Whether pg_stat_statements is created in this database (`installed`) and, if
+ * not, whether it is available to install from the server's contrib packages
+ * (`available`). Drives the "enable" prompt vs. the table.
+ */
+async function checkStatus(pool) {
+  const { rows } = await pool.query(
+    `SELECT EXISTS (SELECT 1 FROM pg_extension          WHERE extname = 'pg_stat_statements') AS installed,
+            EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_stat_statements') AS available`,
+    [],
+  );
+  const row = rows[0] ?? {};
+  return { installed: row.installed === true, available: row.available === true };
+}
+
+/**
+ * Top statements for the current database ordered by the chosen metric. bigint
+ * counters are cast to text so large values survive JSON without precision
+ * loss; the float8 `*_exec_time` columns come back as numbers. Each row gets a
+ * derived `p95_exec_time_est` (see estimateP95).
+ */
+async function topStatements(pool, sort, limit) {
+  const col = sortColumn(sort);
+  const { rows } = await pool.query(
+    `SELECT queryid::text                  AS queryid,
+            query,
+            calls::text                    AS calls,
+            total_exec_time,
+            mean_exec_time,
+            stddev_exec_time,
+            min_exec_time,
+            max_exec_time,
+            rows::text                     AS rows,
+            shared_blks_hit::text          AS shared_blks_hit,
+            shared_blks_read::text         AS shared_blks_read,
+            shared_blks_dirtied::text      AS shared_blks_dirtied,
+            shared_blks_written::text      AS shared_blks_written,
+            local_blks_hit::text           AS local_blks_hit,
+            local_blks_read::text          AS local_blks_read,
+            temp_blks_read::text           AS temp_blks_read,
+            temp_blks_written::text        AS temp_blks_written
+       FROM pg_stat_statements
+      WHERE dbid = (SELECT oid FROM pg_database WHERE datname = current_database())
+      ORDER BY ${col} DESC NULLS LAST
+      LIMIT $1`,
+    [rowLimit(limit)],
+  );
+  return rows.map((r) => ({
+    ...r,
+    p95_exec_time_est: estimateP95(r.mean_exec_time, r.stddev_exec_time, r.max_exec_time),
+  }));
+}
+
+/**
+ * The slow-query payload as a small state machine so the client can render the
+ * right surface without guessing from an error string:
+ *
+ *   not_installed → extension absent; offer the enable DDL (if `available`)
+ *   not_loaded    → extension created but the library isn't in
+ *                   shared_preload_libraries, so the view errors on read
+ *   ready         → `statements` populated
+ */
+async function getStatements(pool, { sort, limit } = {}) {
+  const status = await checkStatus(pool);
+  if (!status.installed) {
+    return { status: 'not_installed', available: status.available, ddl: ENABLE_DDL, statements: [] };
+  }
+  try {
+    const statements = await topStatements(pool, sort, limit);
+    return { status: 'ready', available: true, statements };
+  } catch (err) {
+    // The library must be preloaded; CREATE EXTENSION alone leaves the view
+    // present but unreadable. Treat that as its own state, not a 500.
+    if (/shared_preload_libraries/i.test(err.message)) {
+      return { status: 'not_loaded', available: true, ddl: ENABLE_DDL, statements: [] };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Create the extension (idempotent). Requires a privileged role; the route maps
+ * a failure to a DB error the user can read. Returns the refreshed status so the
+ * client can tell "created, collecting" from "created but needs preload".
+ */
+async function enableStatements(pool) {
+  await pool.query(ENABLE_DDL.replace(/;$/, ''), []);
+  const status = await checkStatus(pool);
+  return { enabled: status.installed, ...status };
+}
+
+/**
+ * Discard all collected statistics (roadmap §6.2: "Reset stats" button) via
+ * pg_stat_statements_reset(). Requires a privileged role.
+ */
+async function resetStatements(pool) {
+  await pool.query('SELECT pg_stat_statements_reset()', []);
+  return { reset: true };
+}
+
+module.exports = {
+  getStatements,
+  enableStatements,
+  resetStatements,
+  checkStatus,
+  estimateP95,
+  sortColumn,
+  rowLimit,
+  SORT_COLUMNS,
+  DEFAULT_SORT,
+  DEFAULT_LIMIT,
+  MAX_LIMIT,
+  ENABLE_DDL,
+  P95_Z,
+};

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -25,6 +25,7 @@ const { IMPORT_MODES, buildImportStatement, batchSizeFor } = require('../db/impo
 const { splitStatements } = require('../db/statements');
 const { extractExplainTiming } = require('../db/explain');
 const operations = require('../db/operations');
+const slowQueries = require('../db/slowQueries');
 const { txManager } = require('../db/tx');
 const views = require('../db/views');
 const savedQueries = require('../db/savedQueries');
@@ -1432,5 +1433,57 @@ router.post('/operations/terminate',
       return sendError(res, 500, codes.DB_ERROR, err.message);
     }
   });
+
+// ---- Slow query view (roadmap §6.2) ----------------------------------------
+//
+// Reads pg_stat_statements. The list response is a small state machine
+// (not_installed / not_loaded / ready) so the client renders the enable prompt
+// or the table without parsing error strings. The sort key is restricted to a
+// fixed allowlist by both the Zod enum here and the server-side SORT_COLUMNS
+// map, so no caller input reaches the ORDER BY.
+
+const StatementsQuery = z.object({
+  sort: z.enum(['total_exec_time', 'mean_exec_time', 'calls']).default('total_exec_time'),
+  limit: z.coerce.number().int().positive().max(slowQueries.MAX_LIMIT).optional(),
+});
+
+router.get('/operations/statements',
+  requireConnection,
+  validate({ query: StatementsQuery }),
+  async (req, res) => {
+    try {
+      const result = await slowQueries.getStatements(req.pool, {
+        sort: req.query.sort,
+        limit: req.query.limit,
+      });
+      res.json(result);
+    } catch (err) {
+      logger.error({ err: err.message }, 'slow query view failed');
+      return sendError(res, 500, codes.DB_ERROR, err.message);
+    }
+  });
+
+router.post('/operations/statements/enable', requireConnection, async (req, res) => {
+  try {
+    const result = await slowQueries.enableStatements(req.pool);
+    res.json(result);
+  } catch (err) {
+    // Typically a privilege error (CREATE EXTENSION needs a superuser).
+    logger.warn({ err: err.message }, 'enable pg_stat_statements failed');
+    return sendError(res, 500, codes.DB_ERROR, err.message, {
+      hint: 'Enabling pg_stat_statements requires a superuser, and collection requires it in shared_preload_libraries.',
+    });
+  }
+});
+
+router.post('/operations/statements/reset', requireConnection, async (req, res) => {
+  try {
+    const result = await slowQueries.resetStatements(req.pool);
+    res.json(result);
+  } catch (err) {
+    logger.warn({ err: err.message }, 'reset pg_stat_statements failed');
+    return sendError(res, 500, codes.DB_ERROR, err.message);
+  }
+});
 
 module.exports = router;

--- a/test/integration/api.test.js
+++ b/test/integration/api.test.js
@@ -25,6 +25,9 @@ process.env.HOME = sandbox;
 process.env.PGLENS_V3 = '0';
 process.env.PGLENS_BIND = '127.0.0.1';
 process.env.PGLENS_LOG_LEVEL = 'warn';
+// Keep secrets out of the real OS keychain — store them in the sandbox so the
+// suite runs headless / on CI / on a broken keychain without prompting.
+process.env.PGLENS_SECRET_STORE = 'file';
 
 const { startServer } = require('../../src/server');
 const { loadOrCreateToken } = require('../../src/auth');
@@ -179,7 +182,7 @@ test('transaction mode: implicit BEGIN, isolation, rollback discards, commit per
     method: 'POST',
     body: JSON.stringify({ tabId: 'query', sql: 'SELECT count(*)::int AS n FROM tx_items' }),
   });
-  assert.equal((await inTx.json()).rows[0].n, 1);
+  assert.equal((await inTx.json()).results[0].rows[0].n, 1);
 
   // Rollback discards the row and closes the session.
   const rb = await (await h('/api/tx/rollback', {
@@ -260,6 +263,50 @@ test('operations dashboard: overview snapshot + backend-action wiring (roadmap �
   const bad = await h('/api/operations/cancel', {
     method: 'POST', body: JSON.stringify({ pid: 0 }),
   });
+  assert.equal(bad.status, 400);
+  assert.equal((await bad.json()).error.code, 'VALIDATION');
+
+  await h('/api/disconnect', { method: 'POST', body: JSON.stringify({ connectionId }) });
+});
+
+test('slow query view: state machine + sort validation (roadmap §6.2)', async () => {
+  const connectRes = await http('/api/connect', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ url: DB_URL, sslMode: 'disable', name: 'slow-itest' }),
+  });
+  const { connectionId } = await connectRes.json();
+  assert.ok(connectionId);
+
+  const h = (path, init = {}) =>
+    http(path, {
+      ...init,
+      headers: {
+        'content-type': 'application/json',
+        'x-connection-id': connectionId,
+        ...(init.headers || {}),
+      },
+    });
+
+  // The list endpoint always answers with one of the three known states; we
+  // don't assume the test server has pg_stat_statements installed/preloaded.
+  const list = await (await h('/api/operations/statements?sort=total_exec_time', { method: 'GET' })).json();
+  assert.ok(['ready', 'not_installed', 'not_loaded'].includes(list.status), `unexpected status ${list.status}`);
+  assert.ok(Array.isArray(list.statements));
+
+  if (list.status === 'ready') {
+    // Real rows carry the derived p95 estimate alongside the raw aggregates.
+    for (const s of list.statements) {
+      assert.ok('p95_exec_time_est' in s);
+      assert.ok('total_exec_time' in s && 'calls' in s);
+    }
+  } else {
+    // Otherwise the enable DDL is offered for the one-click prompt.
+    assert.match(list.ddl, /CREATE EXTENSION IF NOT EXISTS pg_stat_statements/);
+  }
+
+  // A sort key off the allowlist is rejected by validation before any SQL runs.
+  const bad = await h('/api/operations/statements?sort=rows;DROP', { method: 'GET' });
   assert.equal(bad.status, 400);
   assert.equal((await bad.json()).error.code, 'VALIDATION');
 

--- a/test/unit/slowQueries.test.js
+++ b/test/unit/slowQueries.test.js
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for the slow query view (roadmap §6.2).
+ *
+ * Mirrors operations.test.js: a fake pool returns canned rows by SQL substring
+ * so we can assert the status state-machine, the sort allowlist, the row-limit
+ * clamp, and the p95 estimate without a live Postgres + pg_stat_statements.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  getStatements,
+  enableStatements,
+  resetStatements,
+  estimateP95,
+  sortColumn,
+  rowLimit,
+  DEFAULT_LIMIT,
+  MAX_LIMIT,
+} = require('../../src/db/slowQueries');
+
+// Canned rows by SQL substring; records every (sql, params) call. An Error
+// value is thrown when matched, to exercise the not_loaded / failure paths.
+function fakePool(matchers) {
+  const calls = [];
+  return {
+    calls,
+    query: async (sql, params) => {
+      calls.push({ sql, params });
+      for (const [needle, rows] of matchers) {
+        if (sql.includes(needle)) {
+          if (rows instanceof Error) throw rows;
+          return { rows, fields: [], rowCount: rows.length, command: 'SELECT' };
+        }
+      }
+      return { rows: [], fields: [], rowCount: 0, command: 'SELECT' };
+    },
+  };
+}
+
+test('estimateP95 = mean + 1.6449·stddev, clamped to [mean, max]', () => {
+  // Normal case: mean 100, stddev 20 → 100 + 1.6449*20 = 132.898, under max.
+  assert.ok(Math.abs(estimateP95(100, 20, 1000) - 132.898) < 0.01);
+  // Clamped up to the mean when stddev would pull it below (never happens with
+  // a non-negative stddev, but a missing stddev falls back to the mean).
+  assert.equal(estimateP95(50, null, 1000), 50);
+  // Clamped down to the observed max.
+  assert.equal(estimateP95(100, 1000, 120), 120);
+  // Unknown mean → null (nothing to estimate from).
+  assert.equal(estimateP95(null, 20, 100), null);
+  assert.equal(estimateP95(undefined, 20, 100), null);
+});
+
+test('sortColumn only ever yields an allowlisted column', () => {
+  assert.equal(sortColumn('total_exec_time'), 'total_exec_time');
+  assert.equal(sortColumn('mean_exec_time'), 'mean_exec_time');
+  assert.equal(sortColumn('calls'), 'calls');
+  // Anything off the list (including an injection attempt) collapses to the default.
+  assert.equal(sortColumn('rows; DROP TABLE x'), 'total_exec_time');
+  assert.equal(sortColumn(undefined), 'total_exec_time');
+});
+
+test('rowLimit clamps to [1, MAX_LIMIT] and defaults when unset', () => {
+  assert.equal(rowLimit(undefined), DEFAULT_LIMIT);
+  assert.equal(rowLimit(0), DEFAULT_LIMIT);
+  assert.equal(rowLimit(-5), DEFAULT_LIMIT);
+  assert.equal(rowLimit(10), 10);
+  assert.equal(rowLimit(99999), MAX_LIMIT);
+});
+
+test('getStatements reports not_installed when the extension is absent', async () => {
+  const pool = fakePool([['pg_available_extensions', [{ installed: false, available: true }]]]);
+  const result = await getStatements(pool, { sort: 'calls' });
+  assert.equal(result.status, 'not_installed');
+  assert.equal(result.available, true);
+  assert.match(result.ddl, /CREATE EXTENSION IF NOT EXISTS pg_stat_statements/);
+  assert.deepEqual(result.statements, []);
+  // It short-circuits before ever touching the stats view.
+  assert.ok(!pool.calls.some((c) => c.sql.includes('FROM pg_stat_statements\n')));
+});
+
+test('getStatements returns ready rows with a derived p95 and a safe ORDER BY', async () => {
+  const pool = fakePool([
+    ['pg_available_extensions', [{ installed: true, available: true }]],
+    ['FROM pg_stat_statements', [
+      { queryid: '1', query: 'SELECT 1', calls: '10', mean_exec_time: 100, stddev_exec_time: 20, max_exec_time: 500 },
+    ]],
+  ]);
+  const result = await getStatements(pool, { sort: 'mean_exec_time', limit: 25 });
+  assert.equal(result.status, 'ready');
+  assert.equal(result.statements.length, 1);
+  assert.ok(Math.abs(result.statements[0].p95_exec_time_est - 132.898) < 0.01);
+
+  const listCall = pool.calls.find((c) => c.sql.includes('FROM pg_stat_statements'));
+  // Sort key mapped to a real column; limit passed as a bound parameter.
+  assert.match(listCall.sql, /ORDER BY mean_exec_time DESC/);
+  assert.equal(listCall.params[0], 25);
+});
+
+test('getStatements maps a sort key off the allowlist to the default column', async () => {
+  const pool = fakePool([
+    ['pg_available_extensions', [{ installed: true, available: true }]],
+    ['FROM pg_stat_statements', []],
+  ]);
+  await getStatements(pool, { sort: 'evil; DROP TABLE x' });
+  const listCall = pool.calls.find((c) => c.sql.includes('FROM pg_stat_statements'));
+  assert.match(listCall.sql, /ORDER BY total_exec_time DESC/);
+});
+
+test('getStatements distinguishes "created but not preloaded" from a real failure', async () => {
+  const notLoaded = fakePool([
+    ['pg_available_extensions', [{ installed: true, available: true }]],
+    ['FROM pg_stat_statements', new Error('pg_stat_statements must be loaded via shared_preload_libraries')],
+  ]);
+  const result = await getStatements(notLoaded, {});
+  assert.equal(result.status, 'not_loaded');
+  assert.deepEqual(result.statements, []);
+
+  // Any other error still propagates (the route turns it into a 500).
+  const broken = fakePool([
+    ['pg_available_extensions', [{ installed: true, available: true }]],
+    ['FROM pg_stat_statements', new Error('out of memory')],
+  ]);
+  await assert.rejects(() => getStatements(broken, {}), /out of memory/);
+});
+
+test('enableStatements runs CREATE EXTENSION and returns refreshed status', async () => {
+  const pool = fakePool([['pg_available_extensions', [{ installed: true, available: true }]]]);
+  const result = await enableStatements(pool);
+  assert.equal(result.enabled, true);
+  // The DDL is run without a trailing semicolon (single statement).
+  assert.match(pool.calls[0].sql, /^CREATE EXTENSION IF NOT EXISTS pg_stat_statements$/);
+});
+
+test('resetStatements calls pg_stat_statements_reset()', async () => {
+  const pool = fakePool([['pg_stat_statements_reset', [{}]]]);
+  assert.deepEqual(await resetStatements(pool), { reset: true });
+  assert.match(pool.calls[0].sql, /pg_stat_statements_reset\(\)/);
+});


### PR DESCRIPTION
## Slow query view

Adds a **Slow queries** view under Operations, backed by `pg_stat_statements`. Completes Phase 3 §6.2.

### What's in it
- **Top statements** sortable by total exec time, mean exec time, or calls. Sort key maps through a server-side allowlist — no caller input reaches the `ORDER BY`.
- **State machine** (`not_installed` / `not_loaded` / `ready`): one-click **Enable pg_stat_statements** prompt with DDL preview, the `shared_preload_libraries` hint, or the table — never parses error strings.
- **Drilldown** per statement: calls, mean/stddev/min/max time, total IO, cache-hit ratio, and an **estimated p95** (`mean + 1.6449·stddev`, clamped to `[mean, max]` — the view stores no true percentiles; labelled "est.").
- **Reset stats** (`pg_stat_statements_reset`) behind a confirm dialog.
- **Explain in editor**: hands the normalized query to the Query editor as `EXPLAIN (GENERIC_PLAN)` (PG16+), so the `$1/$2` placeholders left by statement normalization plan without bound values instead of failing with *"there is no parameter $1"*.

### Surface area
- Backend: `src/db/slowQueries.js` + `/operations/statements` routes (Zod-validated).
- Frontend: `SlowQueries` page, `slow-queries` tab/route + Sidebar link, Zod-checked API client, one-shot query-seed store for the editor hand-off, shared format helpers extracted out of `Operations`.

### Also included
- `feat(secrets)`: file-based secret store backend (`PGLENS_SECRET_STORE=file`) so tests / headless / broken-keychain machines run `/connect` without a keychain prompt. Separate commit.

### Tests
- Backend unit: 231 ✓ (incl. 9 new `slowQueries`)
- Client unit: 93 ✓ (incl. new slow-query API + `explainSql`)
- Integration: 7/7 ✓
- Typecheck: clean
