### PR TITLE
feat(operations): index assistant

### DIFF
--- a/client-next/src/components/Sidebar.tsx
+++ b/client-next/src/components/Sidebar.tsx
@@ -5,7 +5,8 @@ import {
 } from '@tanstack/react-router'
 import {
   Activity, Bookmark, ChevronDown, ChevronRight, Download, Eye, GitBranch,
-  MoreVertical, Pencil, Plus, Power, Search, Table as TableIcon, Terminal, Timer,
+  Lightbulb, MoreVertical, Pencil, Plus, Power, Search, Table as TableIcon,
+  Terminal, Timer,
 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -325,6 +326,17 @@ export function Sidebar() {
           >
             <Timer className="h-3.5 w-3.5 text-muted-foreground" />
             Slow queries
+          </Link>
+          <Link
+            to="/index-assistant"
+            onClick={() => openTab({ kind: 'index-assistant' })}
+            className={cn(
+              'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
+              !!matchRoute({ to: '/index-assistant' }) && 'bg-accent text-accent-foreground',
+            )}
+          >
+            <Lightbulb className="h-3.5 w-3.5 text-muted-foreground" />
+            Index assistant
           </Link>
         </Section>
       )}

--- a/client-next/src/components/TabBar.tsx
+++ b/client-next/src/components/TabBar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
-import { X, Home, Table as TableIcon, Terminal, GitBranch, Activity, Timer } from 'lucide-react'
+import { X, Home, Table as TableIcon, Terminal, GitBranch, Activity, Timer, Lightbulb } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Dialog } from '@/components/ui/dialog'
@@ -20,6 +20,7 @@ function routeToTab(pathname: string): Tab {
   if (pathname === '/schema') return { kind: 'schema' }
   if (pathname === '/operations') return { kind: 'operations' }
   if (pathname === '/slow-queries') return { kind: 'slow-queries' }
+  if (pathname === '/index-assistant') return { kind: 'index-assistant' }
   return { kind: 'home' }
 }
 
@@ -30,6 +31,7 @@ function tabIcon(t: Tab) {
     case 'schema': return GitBranch
     case 'operations': return Activity
     case 'slow-queries': return Timer
+    case 'index-assistant': return Lightbulb
     case 'home': return Home
   }
 }

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -1252,3 +1252,55 @@ export function enableStatements(connectionId: string) {
 export function resetStatements(connectionId: string) {
   return statementsAction('reset', connectionId)
 }
+
+// ---- Index assistant (roadmap §6.4) -----------------------------------------
+
+// One removable index. `drop_ddl` is generated server-side (properly quoted)
+// for the user to review and run in the editor — pglens never runs it directly.
+const RemovableIndexSchema = z.object({
+  index_name: z.string(),
+  indexdef: z.string(),
+  size_bytes: Numeric,
+  size_pretty: z.string().nullable(),
+  idx_scan: Numeric,
+  drop_ddl: z.string(),
+})
+export type RemovableIndex = z.infer<typeof RemovableIndexSchema>
+
+const UnusedIndexSchema = RemovableIndexSchema.extend({
+  table_name: z.string(),
+})
+export type UnusedIndex = z.infer<typeof UnusedIndexSchema>
+
+// A group of exactly-redundant indexes on one table: keep one, drop the rest.
+const DuplicateGroupSchema = z.object({
+  table_name: z.string(),
+  indexes: z.array(RemovableIndexSchema),
+})
+export type DuplicateGroup = z.infer<typeof DuplicateGroupSchema>
+
+// A table leaning on sequential scans — a missing-index candidate (columns are
+// the user's call; see the server module note on hypopg).
+const SeqScanTableSchema = z.object({
+  table_name: z.string(),
+  seq_scan: Numeric,
+  seq_tup_read: Numeric,
+  idx_scan: Numeric,
+  n_live_tup: Numeric,
+  size_bytes: Numeric,
+  size_pretty: z.string().nullable(),
+})
+export type SeqScanTable = z.infer<typeof SeqScanTableSchema>
+
+// Each section is `{ data, error }` so one failing (e.g. a role without stat
+// visibility) renders inline, not as a blank page — mirrors getAdvice().
+const IndexAdviceSchema = z.object({
+  unused: section(z.array(UnusedIndexSchema)),
+  duplicate: section(z.array(DuplicateGroupSchema)),
+  seqScans: section(z.array(SeqScanTableSchema)),
+})
+export type IndexAdvice = z.infer<typeof IndexAdviceSchema>
+
+export function getIndexAdvice(connectionId: string, signal?: AbortSignal) {
+  return api('/api/operations/indexes', IndexAdviceSchema, { connectionId, signal })
+}

--- a/client-next/src/pages/Home.tsx
+++ b/client-next/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { Plus, ServerCog } from 'lucide-react'
+import { Eye, EyeOff, Plus, ServerCog } from 'lucide-react'
 import { useState } from 'react'
 import { z } from 'zod'
 
@@ -13,6 +13,11 @@ import { useConnectionStore } from '@/store/connection'
 import { useTabsStore } from '@/store/tabs'
 
 const HealthSchema = z.object({ ok: z.boolean(), version: z.string().optional() })
+
+function maskHost(host?: string | null) {
+  if (!host) return '—'
+  return '•'.repeat(Math.min(host.length, 28))
+}
 
 async function fetchHealth() {
   const res = await fetch('/api/v3/health')
@@ -27,6 +32,14 @@ export function Home() {
 
   const [search, setSearch] = useState('')
   const [dialogOpen, setDialogOpen] = useState(false)
+  const [revealed, setRevealed] = useState<Set<string>>(new Set())
+
+  const toggleHost = (id: string) =>
+    setRevealed((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
 
   const health = useQuery({ queryKey: ['health'], queryFn: fetchHealth, retry: false })
   const connections = useQuery({
@@ -107,19 +120,49 @@ export function Home() {
                 <span className="truncate font-medium">{c.name}</span>
               </div>
               <div className="grid gap-1 text-xs text-muted-foreground">
-                <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center justify-between gap-3">
                   <span className="shrink-0">host</span>
-                  <span className="min-w-0 truncate font-mono" title={c.host ?? undefined}>{c.host ?? '—'}</span>
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    <span
+                      className="min-w-0 truncate font-mono"
+                      title={revealed.has(c.id) ? (c.host ?? undefined) : undefined}
+                    >
+                      {revealed.has(c.id) ? (c.host ?? '—') : maskHost(c.host)}
+                    </span>
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      aria-label={revealed.has(c.id) ? 'Hide host' : 'Show host'}
+                      className="shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        toggleHost(c.id)
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          e.stopPropagation()
+                          toggleHost(c.id)
+                        }
+                      }}
+                    >
+                      {revealed.has(c.id) ? (
+                        <EyeOff className="h-3.5 w-3.5" />
+                      ) : (
+                        <Eye className="h-3.5 w-3.5" />
+                      )}
+                    </span>
+                  </span>
                 </div>
-                <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center justify-between gap-3">
                   <span className="shrink-0">database</span>
                   <span className="min-w-0 truncate font-mono" title={c.database ?? undefined}>{c.database ?? '—'}</span>
                 </div>
-                <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center justify-between gap-3">
                   <span className="shrink-0">schema</span>
                   <span className="min-w-0 truncate font-mono" title={c.schema ?? undefined}>{c.schema ?? 'public'}</span>
                 </div>
-                <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center justify-between gap-3">
                   <span className="shrink-0">ssl</span>
                   <span className="min-w-0 truncate font-mono" title={c.sslMode ?? undefined}>{c.sslMode ?? 'prefer'}</span>
                 </div>

--- a/client-next/src/pages/IndexAssistant.tsx
+++ b/client-next/src/pages/IndexAssistant.tsx
@@ -1,0 +1,362 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import {
+  AlertTriangle, Copy as CopyIcon, Database, FileSearch, Layers,
+  Play, RefreshCw, Table as TableIcon, Trash2,
+} from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Loading, Spinner } from '@/components/ui/spinner'
+import {
+  getIndexAdvice,
+  type DuplicateGroup, type RemovableIndex, type SeqScanTable, type UnusedIndex,
+} from '@/lib/api'
+import { cn } from '@/lib/utils'
+import { formatBytes, formatCount, toNum } from '@/lib/format'
+import { useConnectionStore } from '@/store/connection'
+import { useQuerySeedStore } from '@/store/querySeed'
+import { useTabsStore } from '@/store/tabs'
+
+export function IndexAssistant() {
+  const connectionId = useConnectionStore((s) => s.activeConnectionId)
+
+  const advice = useQuery({
+    queryKey: ['index-advice', connectionId],
+    queryFn: ({ signal }) => getIndexAdvice(connectionId!, signal),
+    enabled: !!connectionId,
+    placeholderData: (prev) => prev,
+  })
+
+  if (!connectionId) {
+    return (
+      <div className="px-10 py-10 text-sm text-muted-foreground">
+        No active connection.
+      </div>
+    )
+  }
+
+  const data = advice.data
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="flex items-center justify-between border-b border-border px-6 py-3">
+        <div>
+          <h1 className="text-lg font-semibold">Index assistant</h1>
+          <p className="text-xs text-muted-foreground">
+            Read-only advice from the catalog · suggestions are never run for you
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => advice.refetch()}
+          disabled={advice.isFetching}
+          title="Refresh"
+        >
+          {advice.isFetching ? <Spinner aria-label="Refreshing" /> : <RefreshCw className="h-3.5 w-3.5" />}
+          Refresh
+        </Button>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-auto px-6 py-4">
+        {advice.isLoading && (
+          <div className="py-10 text-center text-sm text-muted-foreground">
+            <Loading>Analyzing indexes…</Loading>
+          </div>
+        )}
+
+        {advice.error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {(advice.error as Error).message}
+          </div>
+        )}
+
+        {data && (
+          <div className="space-y-4">
+            <UnusedPanel section={data.unused} />
+            <DuplicatePanel section={data.duplicate} />
+            <SeqScanPanel section={data.seqScans} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---- Shared editor hand-off -------------------------------------------------
+
+// Seed SQL into the Query editor and jump there — the user reviews and runs it.
+// Reuses the slow-query "Explain in editor" flow; no execute endpoint needed,
+// so a destructive DROP is always behind the editor's Run button.
+function useOpenInEditor() {
+  const navigate = useNavigate()
+  const open = useTabsStore((s) => s.open)
+  return (sql: string) => {
+    useQuerySeedStore.getState().setSeed(sql)
+    open({ kind: 'query' })
+    navigate({ to: '/query' })
+  }
+}
+
+function CopyButton({ text, label = 'Copy DDL' }: { text: string; label?: string }) {
+  const [copied, setCopied] = useState(false)
+  const copy = () => {
+    void navigator.clipboard?.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+  return (
+    <Button size="sm" variant="ghost" className="h-7" onClick={copy}>
+      <CopyIcon className="h-3.5 w-3.5" />
+      {copied ? 'Copied' : label}
+    </Button>
+  )
+}
+
+// ---- Panels -----------------------------------------------------------------
+
+function Panel({
+  title, icon: Icon, count, error, hint, children,
+}: {
+  title: string
+  icon: React.ComponentType<{ className?: string }>
+  count?: number
+  error?: string | null
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="flex flex-col overflow-hidden rounded-lg border border-border bg-card">
+      <header className="flex items-center gap-2 border-b border-border px-4 py-2.5">
+        <Icon className="h-4 w-4 text-muted-foreground" />
+        <h2 className="text-sm font-semibold">{title}</h2>
+        {typeof count === 'number' && (
+          <span className="rounded bg-muted px-1.5 text-[11px] tabular-nums text-muted-foreground">
+            {count}
+          </span>
+        )}
+        {hint && <span className="ml-auto text-[11px] text-muted-foreground">{hint}</span>}
+      </header>
+      <div className="min-h-0 flex-1">
+        {error ? <ErrorNote message={error} /> : children}
+      </div>
+    </section>
+  )
+}
+
+function ErrorNote({ message }: { message: string }) {
+  return (
+    <div className="flex items-start gap-2 px-4 py-3 text-xs text-amber-600 dark:text-amber-400">
+      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  )
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return <p className="px-4 py-6 text-center text-xs text-muted-foreground">{children}</p>
+}
+
+function UnusedPanel({ section }: { section: { data: UnusedIndex[] | null; error: string | null } }) {
+  const open = useOpenInEditor()
+  const rows = section.data ?? []
+  return (
+    <Panel
+      title="Unused indexes"
+      icon={Trash2}
+      count={section.error ? undefined : rows.length}
+      error={section.error}
+      hint="never scanned since stats were last reset"
+    >
+      {rows.length === 0 ? (
+        <Empty>No unused indexes. 🎉</Empty>
+      ) : (
+        <ul className="divide-y divide-border/50">
+          {rows.map((ix) => (
+            <li key={`${ix.table_name}.${ix.index_name}`} className="px-4 py-2.5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 text-xs">
+                    <code className="font-mono font-medium">{ix.index_name}</code>
+                    <span className="text-muted-foreground">on</span>
+                    <code className="font-mono text-muted-foreground">{ix.table_name}</code>
+                  </div>
+                  <code className="mt-1 block truncate font-mono text-[11px] text-muted-foreground" title={ix.indexdef}>
+                    {ix.indexdef}
+                  </code>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <span className="whitespace-nowrap text-xs tabular-nums text-muted-foreground">
+                    {formatBytes(ix.size_bytes)}
+                  </span>
+                  <CopyButton text={ix.drop_ddl} />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7"
+                    title="Review the DROP in the editor"
+                    onClick={() => open(ix.drop_ddl)}
+                  >
+                    <Play className="h-3.5 w-3.5" />
+                    Review drop
+                  </Button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Panel>
+  )
+}
+
+function DuplicatePanel({ section }: { section: { data: DuplicateGroup[] | null; error: string | null } }) {
+  const open = useOpenInEditor()
+  const groups = section.data ?? []
+  return (
+    <Panel
+      title="Duplicate indexes"
+      icon={Layers}
+      count={section.error ? undefined : groups.length}
+      error={section.error}
+      hint="identical column list — keep one, drop the rest"
+    >
+      {groups.length === 0 ? (
+        <Empty>No duplicate indexes.</Empty>
+      ) : (
+        <ul className="divide-y divide-border/50">
+          {groups.map((g) => (
+            <li key={g.table_name + g.indexes.map((i) => i.index_name).join(',')} className="px-4 py-2.5">
+              <div className="mb-1.5 flex items-center gap-2 text-xs">
+                <TableIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                <code className="font-mono text-muted-foreground">{g.table_name}</code>
+              </div>
+              <ul className="space-y-1.5 pl-5">
+                {g.indexes.map((ix: RemovableIndex, i) => (
+                  <li key={ix.index_name} className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 text-xs">
+                        <code className="font-mono font-medium">{ix.index_name}</code>
+                        {i === 0 && (
+                          <span className="rounded bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+                            largest — keep
+                          </span>
+                        )}
+                      </div>
+                      <code className="mt-0.5 block truncate font-mono text-[11px] text-muted-foreground" title={ix.indexdef}>
+                        {ix.indexdef}
+                      </code>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <span className="whitespace-nowrap text-xs tabular-nums text-muted-foreground">
+                        {formatBytes(ix.size_bytes)}
+                      </span>
+                      <CopyButton text={ix.drop_ddl} />
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7"
+                        title="Review the DROP in the editor"
+                        onClick={() => open(ix.drop_ddl)}
+                      >
+                        <Play className="h-3.5 w-3.5" />
+                        Review drop
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Panel>
+  )
+}
+
+function SeqScanPanel({ section }: { section: { data: SeqScanTable[] | null; error: string | null } }) {
+  const navigate = useNavigate()
+  const open = useTabsStore((s) => s.open)
+  const rows = section.data ?? []
+  const goToTable = (name: string) => {
+    open({ kind: 'table', tableName: name })
+    navigate({ to: '/tables/$tableName', params: { tableName: name } })
+  }
+  return (
+    <Panel
+      title="Tables relying on sequential scans"
+      icon={FileSearch}
+      count={section.error ? undefined : rows.length}
+      error={section.error}
+      hint="missing-index candidates"
+    >
+      {rows.length === 0 ? (
+        <Empty>No tables are leaning on sequential scans.</Empty>
+      ) : (
+        <div className="overflow-auto">
+          <table className="w-full text-left text-xs">
+            <thead className="text-muted-foreground">
+              <tr className="border-b border-border">
+                <Th>Table</Th>
+                <Th className="text-right">Rows</Th>
+                <Th className="text-right">Seq scans</Th>
+                <Th className="text-right">Index scans</Th>
+                <Th className="text-right" title="Average rows read per sequential scan">Rows / seq scan</Th>
+                <Th className="text-right">Size</Th>
+                <Th />
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((t) => (
+                <tr key={t.table_name} className="border-b border-border/50">
+                  <Td className="max-w-[14rem] truncate" title={t.table_name}>
+                    <code className="font-mono">{t.table_name}</code>
+                  </Td>
+                  <Td className="text-right tabular-nums">{formatCount(t.n_live_tup)}</Td>
+                  <Td className="text-right tabular-nums font-medium">{formatCount(t.seq_scan)}</Td>
+                  <Td className="text-right tabular-nums text-muted-foreground">{formatCount(t.idx_scan)}</Td>
+                  <Td className="text-right tabular-nums">{formatCount(perScan(t.seq_tup_read, t.seq_scan))}</Td>
+                  <Td className="text-right tabular-nums text-muted-foreground">{formatBytes(t.size_bytes)}</Td>
+                  <Td className="text-right">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7"
+                      title="Open this table"
+                      onClick={() => goToTable(t.table_name)}
+                    >
+                      <Database className="h-3.5 w-3.5" />
+                      Open
+                    </Button>
+                  </Td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Panel>
+  )
+}
+
+// ---- Small bits -------------------------------------------------------------
+
+function Th({ children, className, title }: { children?: React.ReactNode; className?: string; title?: string }) {
+  return <th className={cn('px-3 py-1.5 font-medium', className)} title={title}>{children}</th>
+}
+
+function Td({ children, className, title }: { children: React.ReactNode; className?: string; title?: string }) {
+  return <td className={cn('px-3 py-1.5', className)} title={title}>{children}</td>
+}
+
+function perScan(
+  read: number | string | null | undefined,
+  scans: number | string | null | undefined,
+): number | null {
+  const r = toNum(read)
+  const s = toNum(scans)
+  if (r == null || s == null || s === 0) return null
+  return r / s
+}

--- a/client-next/src/routeTree.tsx
+++ b/client-next/src/routeTree.tsx
@@ -5,6 +5,7 @@ import { SchemaViz } from './pages/SchemaViz'
 import { QueryRunner } from './pages/QueryRunner'
 import { Operations } from './pages/Operations'
 import { SlowQueries } from './pages/SlowQueries'
+import { IndexAssistant } from './pages/IndexAssistant'
 import { Sidebar } from './components/Sidebar'
 import { TabBar } from './components/TabBar'
 import { Spotlight } from './components/Spotlight'
@@ -83,6 +84,12 @@ const slowQueriesRoute = createRoute({
   component: SlowQueries,
 })
 
+const indexAssistantRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/index-assistant',
+  component: IndexAssistant,
+})
+
 export const routeTree = rootRoute.addChildren([
   homeRoute,
   tableRoute,
@@ -90,4 +97,5 @@ export const routeTree = rootRoute.addChildren([
   queryRoute,
   operationsRoute,
   slowQueriesRoute,
+  indexAssistantRoute,
 ])

--- a/client-next/src/store/tabs.ts
+++ b/client-next/src/store/tabs.ts
@@ -6,6 +6,7 @@ export type Tab =
   | { kind: 'schema' }
   | { kind: 'operations' }
   | { kind: 'slow-queries' }
+  | { kind: 'index-assistant' }
   | { kind: 'home' }
 
 function tabId(t: Tab): string {
@@ -15,6 +16,7 @@ function tabId(t: Tab): string {
     case 'schema': return 'schema'
     case 'operations': return 'operations'
     case 'slow-queries': return 'slow-queries'
+    case 'index-assistant': return 'index-assistant'
     case 'home': return 'home'
   }
 }
@@ -26,6 +28,7 @@ function tabLabel(t: Tab): string {
     case 'schema': return 'Schema'
     case 'operations': return 'Operations'
     case 'slow-queries': return 'Slow queries'
+    case 'index-assistant': return 'Index assistant'
     case 'home': return 'Home'
   }
 }
@@ -37,6 +40,7 @@ function tabRoute(t: Tab): string {
     case 'schema': return '/schema'
     case 'operations': return '/operations'
     case 'slow-queries': return '/slow-queries'
+    case 'index-assistant': return '/index-assistant'
     case 'home': return '/'
   }
 }

--- a/src/db/indexAdvisor.js
+++ b/src/db/indexAdvisor.js
@@ -1,0 +1,193 @@
+/**
+ * Index assistant — Postgres-native operations (roadmap §6.4).
+ *
+ * Read-only advice derived entirely from the server's own catalogs/stat views,
+ * surfaced in the "Index assistant" panel:
+ *
+ *   - Unused indexes      → pg_stat_user_indexes where idx_scan = 0
+ *   - Duplicate indexes   → pg_index grouped by (table, columns, opclass,
+ *                           collation, expr, predicate, access method)
+ *   - Heavy seq scans     → pg_stat_user_tables (missing-index candidates)
+ *
+ * Like src/db/operations.js, every function takes the wrapped pool from
+ * `requireConnection` (req.pool) and runs parameterized queries against system
+ * views — no caller-supplied SQL ever reaches the server. The only generated
+ * SQL is the DROP DDL attached to each removable index, built through the same
+ * identifier escaper the rest of the app uses; it is shown for review and run
+ * by the user in the editor, never executed by this module.
+ *
+ * ponytail: the "suggest CREATE INDEX (status, created_at) for this filter"
+ * recommender from the roadmap needs hypopg or query-plan parsing to pick the
+ * columns — skipped. The seq-scan section is the catalog-only proxy: it flags
+ * which tables lean on sequential scans; the user picks the columns. Add the
+ * column recommender when hypopg integration lands. Bloat (pgstattuple) is also
+ * skipped — pgstattuple scans the whole relation, too costly for an interactive
+ * panel; add it behind an explicit per-table "analyze bloat" action.
+ */
+
+const { quoteQualifiedIdent } = require('./identifier');
+
+// Top-N per section, so a database with thousands of indexes/tables can't blow
+// up the payload. Generous enough that real advisories are never truncated.
+const TOP = 50;
+
+// Tables below this live-row estimate are excluded from the seq-scan section:
+// a sequential scan of a small table is the planner's correct choice, and an
+// index there is noise, not a fix.
+const SEQ_SCAN_MIN_ROWS = 10_000;
+
+/** DROP DDL for one index, with both identifiers properly quoted. */
+function buildDropIndexDdl(schema, indexName) {
+  return `DROP INDEX ${quoteQualifiedIdent(schema, indexName)};`;
+}
+
+/**
+ * Indexes never used since the stats were last reset (idx_scan = 0). Primary
+ * keys, unique, and exclusion-constraint indexes are excluded — dropping them
+ * would change semantics, not just reclaim space — as are invalid/half-built
+ * indexes. Largest first, so the biggest reclaimable space is on top.
+ */
+async function getUnusedIndexes(pool, schema) {
+  const { rows } = await pool.query(
+    `SELECT s.relname        AS table_name,
+            s.indexrelname   AS index_name,
+            s.idx_scan::text AS idx_scan,
+            pg_relation_size(s.indexrelid)                 AS size_bytes,
+            pg_size_pretty(pg_relation_size(s.indexrelid)) AS size_pretty,
+            pg_get_indexdef(s.indexrelid)                  AS indexdef
+       FROM pg_stat_user_indexes s
+       JOIN pg_index i ON i.indexrelid = s.indexrelid
+      WHERE s.schemaname = $1
+        AND s.idx_scan = 0
+        AND i.indisvalid
+        AND NOT i.indisprimary
+        AND NOT i.indisunique
+        AND NOT i.indisexclusion
+      ORDER BY pg_relation_size(s.indexrelid) DESC
+      LIMIT $2`,
+    [schema, TOP],
+  );
+  return rows.map((r) => ({ ...r, drop_ddl: buildDropIndexDdl(schema, r.index_name) }));
+}
+
+/**
+ * Groups of exactly-redundant indexes: same table, same column list, opclasses,
+ * collations, expression, predicate, and access method. Each group is two or
+ * more indexes that do the same job — keep one, drop the rest. Each index in a
+ * group carries its own DROP DDL so the user can choose which to remove.
+ *
+ * "Exact" is deliberate: a prefix-redundant index (one on (a) covered by
+ * another on (a, b)) is *not* flagged here — that needs prefix matching and is
+ * a softer call. Add it when the simple exact match proves insufficient.
+ */
+async function getDuplicateIndexes(pool, schema) {
+  const { rows } = await pool.query(
+    `WITH idx AS (
+       SELECT i.indrelid,
+              ct.relname AS table_name,
+              ci.relname AS index_name,
+              am.amname,
+              i.indkey::text       AS k_cols,
+              i.indclass::text     AS k_class,
+              i.indcollation::text AS k_coll,
+              COALESCE(pg_get_expr(i.indexprs, i.indrelid), '') AS k_expr,
+              COALESCE(pg_get_expr(i.indpred,  i.indrelid), '') AS k_pred,
+              pg_relation_size(i.indexrelid)                 AS size_bytes,
+              pg_size_pretty(pg_relation_size(i.indexrelid)) AS size_pretty,
+              pg_get_indexdef(i.indexrelid)                  AS indexdef,
+              s.idx_scan
+         FROM pg_index i
+         JOIN pg_class ci    ON ci.oid = i.indexrelid
+         JOIN pg_class ct    ON ct.oid = i.indrelid
+         JOIN pg_namespace n ON n.oid  = ct.relnamespace
+         JOIN pg_am am       ON am.oid = ci.relam
+         LEFT JOIN pg_stat_user_indexes s ON s.indexrelid = i.indexrelid
+        WHERE n.nspname = $1
+          AND i.indisvalid
+          AND ct.relkind IN ('r', 'p', 'm')
+     )
+     SELECT table_name,
+            json_agg(json_build_object(
+              'index_name', index_name,
+              'indexdef',   indexdef,
+              'size_bytes', size_bytes,
+              'size_pretty', size_pretty,
+              'idx_scan',   idx_scan::text
+            ) ORDER BY size_bytes DESC, index_name) AS indexes
+       FROM idx
+      GROUP BY indrelid, table_name, amname, k_cols, k_class, k_coll, k_expr, k_pred
+     HAVING count(*) > 1
+      ORDER BY table_name
+      LIMIT $2`,
+    [schema, TOP],
+  );
+  return rows.map((g) => ({
+    table_name: g.table_name,
+    indexes: (g.indexes || []).map((ix) => ({
+      ...ix,
+      drop_ddl: buildDropIndexDdl(schema, ix.index_name),
+    })),
+  }));
+}
+
+/**
+ * Tables leaning on sequential scans (roadmap §6.4 missing-index proxy): more
+ * seq scans than index scans, on a table large enough that an index would help.
+ * Worst total rows read by seq scans first. No CREATE DDL is generated — the
+ * right columns depend on the query, which the catalogs don't record (see the
+ * module note on hypopg).
+ */
+async function getSeqScanTables(pool, schema) {
+  const { rows } = await pool.query(
+    `SELECT relname                           AS table_name,
+            seq_scan::text                    AS seq_scan,
+            seq_tup_read::text                AS seq_tup_read,
+            COALESCE(idx_scan, 0)::text       AS idx_scan,
+            n_live_tup::text                  AS n_live_tup,
+            pg_relation_size(relid)                 AS size_bytes,
+            pg_size_pretty(pg_relation_size(relid)) AS size_pretty
+       FROM pg_stat_user_tables
+      WHERE schemaname = $1
+        AND seq_scan > 0
+        AND n_live_tup >= $2
+        AND seq_scan > COALESCE(idx_scan, 0)
+      ORDER BY seq_tup_read DESC
+      LIMIT $3`,
+    [schema, SEQ_SCAN_MIN_ROWS, TOP],
+  );
+  return rows;
+}
+
+/**
+ * Assemble all three sections in one round trip. Readers run in parallel and
+ * each is isolated: a section that throws (e.g. a role without stat visibility)
+ * comes back as `{ data: null, error }` so the rest of the panel renders —
+ * mirrors operations.getOverview().
+ */
+async function getAdvice(pool, schema) {
+  const readers = {
+    unused: () => getUnusedIndexes(pool, schema),
+    duplicate: () => getDuplicateIndexes(pool, schema),
+    seqScans: () => getSeqScanTables(pool, schema),
+  };
+  const entries = await Promise.all(
+    Object.entries(readers).map(async ([key, run]) => {
+      try {
+        return [key, { data: await run(), error: null }];
+      } catch (err) {
+        return [key, { data: null, error: err.message }];
+      }
+    }),
+  );
+  return Object.fromEntries(entries);
+}
+
+module.exports = {
+  getAdvice,
+  getUnusedIndexes,
+  getDuplicateIndexes,
+  getSeqScanTables,
+  buildDropIndexDdl,
+  TOP,
+  SEQ_SCAN_MIN_ROWS,
+};

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -26,6 +26,7 @@ const { splitStatements } = require('../db/statements');
 const { extractExplainTiming } = require('../db/explain');
 const operations = require('../db/operations');
 const slowQueries = require('../db/slowQueries');
+const indexAdvisor = require('../db/indexAdvisor');
 const { txManager } = require('../db/tx');
 const views = require('../db/views');
 const savedQueries = require('../db/savedQueries');
@@ -1493,6 +1494,23 @@ router.post('/operations/statements/reset', requireConnection, async (req, res) 
     res.json(result);
   } catch (err) {
     logger.warn({ err: err.message }, 'reset pg_stat_statements failed');
+    return sendError(res, 500, codes.DB_ERROR, err.message);
+  }
+});
+
+// ---- Index assistant (roadmap §6.4) ----------------------------------------
+//
+// Read-only catalog advice (unused / duplicate indexes + heavy seq-scan
+// tables). Each section degrades independently inside getAdvice(), so the route
+// only 500s on a hard failure. The DROP DDL each removable index carries is for
+// the user to review and run in the editor — nothing here executes it.
+
+router.get('/operations/indexes', requireConnection, async (req, res) => {
+  try {
+    const advice = await indexAdvisor.getAdvice(req.pool, req.schema);
+    res.json(advice);
+  } catch (err) {
+    logger.error({ err: err.message }, 'index assistant failed');
     return sendError(res, 500, codes.DB_ERROR, err.message);
   }
 });

--- a/test/unit/indexAdvisor.test.js
+++ b/test/unit/indexAdvisor.test.js
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the index assistant (roadmap §6.4).
+ *
+ * A fake pool returns canned catalog rows by matching a substring of the SQL,
+ * so we can assert the DROP-DDL generation (the one security-relevant pure bit,
+ * since it interpolates identifiers) and getAdvice()'s "one bad section
+ * degrades, the rest survive" contract — without a live Postgres.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  getAdvice,
+  getUnusedIndexes,
+  getDuplicateIndexes,
+  buildDropIndexDdl,
+} = require('../../src/db/indexAdvisor');
+
+function fakePool(matchers) {
+  const calls = [];
+  return {
+    calls,
+    query: async (sql, params) => {
+      calls.push({ sql, params });
+      for (const [needle, rows] of matchers) {
+        if (sql.includes(needle)) {
+          if (rows instanceof Error) throw rows;
+          return { rows, fields: [], rowCount: rows.length, command: 'SELECT' };
+        }
+      }
+      return { rows: [], fields: [], rowCount: 0, command: 'SELECT' };
+    },
+  };
+}
+
+test('buildDropIndexDdl quotes and escapes both identifiers', () => {
+  assert.equal(buildDropIndexDdl('public', 'idx_foo'), 'DROP INDEX "public"."idx_foo";');
+  // Embedded double quotes are doubled — no SQL injection through an index name.
+  assert.equal(
+    buildDropIndexDdl('public', 'evil"; DROP TABLE users; --'),
+    'DROP INDEX "public"."evil""; DROP TABLE users; --";',
+  );
+});
+
+test('getUnusedIndexes attaches DROP DDL and passes the schema', async () => {
+  const pool = fakePool([
+    ['pg_stat_user_indexes', [
+      { table_name: 'orders', index_name: 'idx_old', idx_scan: '0',
+        size_bytes: 1024, size_pretty: '1 kB', indexdef: 'CREATE INDEX ...' },
+    ]],
+  ]);
+  const rows = await getUnusedIndexes(pool, 'shop');
+  assert.equal(pool.calls[0].params[0], 'shop');
+  assert.equal(rows[0].drop_ddl, 'DROP INDEX "shop"."idx_old";');
+});
+
+test('getDuplicateIndexes attaches per-index DROP DDL within each group', async () => {
+  const pool = fakePool([
+    ['HAVING count(*) > 1', [
+      { table_name: 'orders', indexes: [
+        { index_name: 'idx_a', indexdef: 'CREATE INDEX ...', size_bytes: 2048, size_pretty: '2 kB', idx_scan: '5' },
+        { index_name: 'idx_b', indexdef: 'CREATE INDEX ...', size_bytes: 2048, size_pretty: '2 kB', idx_scan: '0' },
+      ] },
+    ]],
+  ]);
+  const groups = await getDuplicateIndexes(pool, 'public');
+  assert.equal(groups[0].indexes[0].drop_ddl, 'DROP INDEX "public"."idx_a";');
+  assert.equal(groups[0].indexes[1].drop_ddl, 'DROP INDEX "public"."idx_b";');
+});
+
+test('getAdvice isolates a failing section', async () => {
+  const pool = fakePool([
+    // `idx_scan = 0` is unique to the unused-index query — the duplicate query
+    // also mentions pg_stat_user_indexes (a LEFT JOIN), so match on the filter.
+    ['idx_scan = 0', new Error('permission denied for pg_stat_user_indexes')],
+    ['HAVING count(*) > 1', [{ table_name: 't', indexes: [] }]],
+    ['pg_stat_user_tables', [{ table_name: 'big', seq_scan: '99' }]],
+  ]);
+  const advice = await getAdvice(pool, 'public');
+
+  assert.equal(advice.unused.data, null);
+  assert.match(advice.unused.error, /permission denied/);
+
+  assert.equal(advice.duplicate.error, null);
+  assert.ok(Array.isArray(advice.duplicate.data));
+  assert.equal(advice.seqScans.error, null);
+  assert.equal(advice.seqScans.data[0].table_name, 'big');
+});


### PR DESCRIPTION
## Summary

Adds the **Index assistant** (roadmap §6.4) as a new Operations page, plus a small Home-page connection-host masking fix.

### Index assistant (b61ca99)
Catalog-driven, read-only index advice — mirrors the live-activity / slow-query pattern. All queries parameterized against system views; no caller SQL reaches the server.

Three sections, each isolated so one failing role-permission degrades to an inline note instead of blanking the page:
- **Unused indexes** — `pg_stat_user_indexes` `idx_scan = 0`, excluding primary/unique/exclusion/invalid (dropping those changes semantics, not just space).
- **Duplicate indexes** — `pg_index` grouped by table + columns + opclass + collation + expression + predicate + access method (exact redundancy only).
- **Heavy seq scans** — `pg_stat_user_tables`, the missing-index proxy.

Each removable index carries a DROP DDL built through the identifier escaper. Suggestions are handed to the SQL editor via the existing query-seed flow, so a destructive DROP only ever runs behind the editor's Run button — nothing executes automatically.

New surface: `GET /api/operations/indexes`, `src/db/indexAdvisor.js`, `client-next/src/pages/IndexAssistant.tsx`, wired into route/tab/sidebar.

**Deferred:** CREATE INDEX column recommender (needs hypopg/plan parsing), bloat via pgstattuple (full-relation scan, too costly interactively), prefix-redundant detection.

### Home host masking (a506eda)
Mask connection host with a toggle, clip overflow.

## Test plan
- `npm test` — 235 backend unit tests pass (incl. 4 new in `test/unit/indexAdvisor.test.js`: DDL escaping + section isolation).
- `client-next`: `npm run typecheck` clean, `npm test` 117 pass.