### PR TITLE
feat(schema-diff): schema diff & migration generator (roadmap §7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Phase 4 (part 1) — Smart features. Schema diff & migration generator: the
+start of the v3.5.0 set.
+
+### Added
+
+- **Schema diff & migration generator** (roadmap §7.1). A new "Diff &
+  migrate" tool (`GET /api/schema-diff?source=<id>&target=<id>`) that
+  introspects two connected databases — each at its configured schema — and
+  produces a structured diff plus a **forward** (source→target) and
+  **backward** (target→source) migration. The analytical core is pure and
+  unit-tested (`src/db/schemaDiff.js`): Postgres renders the constraint/index
+  DDL via `pg_get_constraintdef`/`pg_get_indexdef`, while `diffSchemas` and
+  `buildMigration` (the reverse is just the same builder with arguments
+  swapped) run on plain snapshots. Generated statements are ordered for
+  dependency safety (create tables / add columns before altering; drop FKs and
+  indexes before the columns under them; non-FK constraints before FKs; drops
+  last) and each carries a `destructive` flag (DROP table/column/constraint/
+  index and column-type changes) so the UI highlights them red. Like the index
+  assistant, **nothing is executed**: the migration goes to the editor behind
+  the Run button, opened against the connection it targets.
+  - _Deferred:_ diffing a live DB against a `.sql` baseline file (needs a DDL
+    parser), Flyway/Alembic/Knex/Prisma output formats, and cross-schema-name
+    diffs — all noted in the module header.
+
 ## [3.4.0] - 2026-06-23
 
 Phase 3 (part 2) — Postgres-native operations. The EXPLAIN plan visualizer

--- a/client-next/src/components/CopyButton.tsx
+++ b/client-next/src/components/CopyButton.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { Copy as CopyIcon } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { copyText } from '@/lib/clipboard'
+import { cn } from '@/lib/utils'
+
+/** Copy-to-clipboard button that flips to "Copied" for 1.5s on success. */
+export function CopyButton({
+  text, label = 'Copy', className,
+}: {
+  text: string
+  label?: string
+  className?: string
+}) {
+  const [copied, setCopied] = useState(false)
+  const onCopy = () => {
+    void copyText(text).then((ok) => {
+      if (!ok) return
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+  return (
+    <Button size="sm" variant="ghost" className={cn('h-7', className)} onClick={onCopy}>
+      <CopyIcon className="h-3.5 w-3.5" />
+      {copied ? 'Copied' : label}
+    </Button>
+  )
+}

--- a/client-next/src/components/Sidebar.tsx
+++ b/client-next/src/components/Sidebar.tsx
@@ -5,8 +5,8 @@ import {
 } from '@tanstack/react-router'
 import {
   Activity, Bookmark, ChevronDown, ChevronRight, Download, Eye, GitBranch,
-  Lightbulb, MoreVertical, Pencil, Plus, Power, Search, Table as TableIcon,
-  Terminal, Timer,
+  GitCompare, Lightbulb, MoreVertical, Pencil, Plus, Power, Search,
+  Table as TableIcon, Terminal, Timer,
 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -287,6 +287,17 @@ export function Sidebar() {
           >
             <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
             Query
+          </Link>
+          <Link
+            to="/schema-diff"
+            onClick={() => openTab({ kind: 'schema-diff' })}
+            className={cn(
+              'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
+              !!matchRoute({ to: '/schema-diff' }) && 'bg-accent text-accent-foreground',
+            )}
+          >
+            <GitCompare className="h-3.5 w-3.5 text-muted-foreground" />
+            Diff &amp; migrate
           </Link>
           <button
             onClick={() => exportMut.mutate(activeConn.id)}

--- a/client-next/src/components/TabBar.tsx
+++ b/client-next/src/components/TabBar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
-import { X, Home, Table as TableIcon, Terminal, GitBranch, Activity, Timer, Lightbulb } from 'lucide-react'
+import { X, Home, Table as TableIcon, Terminal, GitBranch, GitCompare, Activity, Timer, Lightbulb } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Dialog } from '@/components/ui/dialog'
@@ -21,6 +21,7 @@ function routeToTab(pathname: string): Tab {
   if (pathname === '/operations') return { kind: 'operations' }
   if (pathname === '/slow-queries') return { kind: 'slow-queries' }
   if (pathname === '/index-assistant') return { kind: 'index-assistant' }
+  if (pathname === '/schema-diff') return { kind: 'schema-diff' }
   return { kind: 'home' }
 }
 
@@ -32,6 +33,7 @@ function tabIcon(t: Tab) {
     case 'operations': return Activity
     case 'slow-queries': return Timer
     case 'index-assistant': return Lightbulb
+    case 'schema-diff': return GitCompare
     case 'home': return Home
   }
 }

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { downloadBlob } from '@/lib/download'
+
 const ConnectionSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -145,16 +147,28 @@ async function postJson<T>(
   body: unknown,
   schema: z.ZodSchema<T>,
   method: 'POST' | 'PUT' | 'PATCH' = 'POST',
+  connectionId?: string,
 ): Promise<T> {
+  const headers: Record<string, string> = { 'content-type': 'application/json' }
+  if (connectionId) headers['x-connection-id'] = connectionId
   const res = await fetch(path, {
     method,
-    headers: { 'content-type': 'application/json' },
+    headers,
     body: JSON.stringify(body),
     credentials: 'same-origin',
   })
   const json = await res.json().catch(() => null)
   if (!res.ok) throw parseErrorBody(json, res.status)
   return schema.parse(json)
+}
+
+// DELETE with the standard error envelope. Parses the body only when a schema
+// is given (most deletes return nothing the caller needs).
+async function del<T = void>(path: string, schema?: z.ZodSchema<T>): Promise<T> {
+  const res = await fetch(path, { method: 'DELETE', credentials: 'same-origin' })
+  const json = await res.json().catch(() => null)
+  if (!res.ok) throw parseErrorBody(json, res.status)
+  return (schema ? schema.parse(json) : undefined) as T
 }
 
 export function connect(payload: ConnectPayload) {
@@ -210,24 +224,14 @@ function explainBody(options: RunQueryOptions) {
   return { explain: true, analyze: options.analyze === false ? false : undefined }
 }
 
-export async function runQuery(
+export function runQuery(
   connectionId: string,
   sql: string,
   params?: unknown[],
   options: RunQueryOptions = {},
 ): Promise<QueryResult> {
-  const res = await fetch('/api/query', {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      'x-connection-id': connectionId,
-    },
-    body: JSON.stringify({ sql, params, ...explainBody(options) }),
-    credentials: 'same-origin',
-  })
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return QueryResponse.parse(json)
+  return postJson('/api/query', { sql, params, ...explainBody(options) },
+    QueryResponse, 'POST', connectionId)
 }
 
 // ---- Transaction mode (roadmap §5.3) ----------------------------------------
@@ -241,22 +245,15 @@ export type TxQueryResult = z.infer<typeof TxQueryResponse>
  * serves every subsequent statement until commit/rollback. `txOpen` reflects
  * whether the tab still holds a transaction afterward.
  */
-export async function runTxQuery(
+export function runTxQuery(
   connectionId: string,
   tabId: string,
   sql: string,
   params?: unknown[],
   options: RunQueryOptions = {},
 ): Promise<TxQueryResult> {
-  const res = await fetch('/api/tx/query', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'x-connection-id': connectionId },
-    body: JSON.stringify({ tabId, sql, params, ...explainBody(options) }),
-    credentials: 'same-origin',
-  })
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return TxQueryResponse.parse(json)
+  return postJson('/api/tx/query', { tabId, sql, params, ...explainBody(options) },
+    TxQueryResponse, 'POST', connectionId)
 }
 
 const TxControlResponse = z.object({
@@ -265,20 +262,12 @@ const TxControlResponse = z.object({
   hadTransaction: z.boolean(),
 })
 
-async function txControl(
+function txControl(
   action: 'commit' | 'rollback',
   connectionId: string,
   tabId: string,
 ) {
-  const res = await fetch(`/api/tx/${action}`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'x-connection-id': connectionId },
-    body: JSON.stringify({ tabId }),
-    credentials: 'same-origin',
-  })
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return TxControlResponse.parse(json)
+  return postJson(`/api/tx/${action}`, { tabId }, TxControlResponse, 'POST', connectionId)
 }
 
 export function commitTx(connectionId: string, tabId: string) {
@@ -322,19 +311,8 @@ export function patchSchema(connectionId: string, schema: string) {
 
 const DisconnectResponse = z.object({ connected: z.boolean() })
 
-export async function disconnect(connectionId: string) {
-  const res = await fetch('/api/disconnect', {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      'x-connection-id': connectionId,
-    },
-    body: JSON.stringify({ connectionId }),
-    credentials: 'same-origin',
-  })
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return DisconnectResponse.parse(json)
+export function disconnect(connectionId: string) {
+  return postJson('/api/disconnect', { connectionId }, DisconnectResponse, 'POST', connectionId)
 }
 
 export interface BackupProgress {
@@ -365,7 +343,7 @@ export async function downloadBackup(
   if (!res.body) {
     // Fallback for environments without ReadableStream.
     const blob = await res.blob()
-    triggerDownload(blob, fileName)
+    downloadBlob(blob, fileName)
     onProgress?.({ bytes: blob.size })
     return
   }
@@ -395,19 +373,8 @@ export async function downloadBackup(
     onProgress?.({ bytes, currentTable })
   }
 
-  triggerDownload(new Blob(chunks, { type: 'application/sql' }), fileName)
+  downloadBlob(new Blob(chunks, { type: 'application/sql' }), fileName)
   onProgress?.({ bytes, currentTable })
-}
-
-function triggerDownload(blob: Blob, fileName: string) {
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = fileName
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
 }
 
 export type ExportFormat = 'csv' | 'json' | 'sql'
@@ -475,7 +442,7 @@ export async function exportTableData(
   if (!res.body) {
     // Fallback for environments without ReadableStream.
     const blob = await res.blob()
-    triggerDownload(blob, fileName)
+    downloadBlob(blob, fileName)
     onProgress?.({ bytes: blob.size })
     return { bytes: blob.size }
   }
@@ -491,7 +458,7 @@ export async function exportTableData(
     onProgress?.({ bytes })
   }
 
-  triggerDownload(new Blob(chunks, { type: contentType }), fileName)
+  downloadBlob(new Blob(chunks, { type: contentType }), fileName)
   onProgress?.({ bytes })
   return { bytes }
 }
@@ -661,41 +628,18 @@ export function listViews(
 }
 
 export async function createView(payload: SaveViewPayload): Promise<SavedView> {
-  const res = await fetch('/api/views', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(payload),
-    credentials: 'same-origin',
-  })
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return ViewEnvelope.parse(json).view
+  return (await postJson('/api/views', payload, ViewEnvelope)).view
 }
 
 export async function updateView(
   id: string,
   patch: Partial<SaveViewPayload>,
 ): Promise<SavedView> {
-  const res = await fetch(`/api/views/${encodeURIComponent(id)}`, {
-    method: 'PUT',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(patch),
-    credentials: 'same-origin',
-  })
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return ViewEnvelope.parse(json).view
+  return (await postJson(`/api/views/${encodeURIComponent(id)}`, patch, ViewEnvelope, 'PUT')).view
 }
 
-export async function deleteView(id: string): Promise<void> {
-  const res = await fetch(`/api/views/${encodeURIComponent(id)}`, {
-    method: 'DELETE',
-    credentials: 'same-origin',
-  })
-  if (!res.ok) {
-    const json = await res.json().catch(() => null)
-    throw parseErrorBody(json, res.status)
-  }
+export function deleteView(id: string): Promise<void> {
+  return del(`/api/views/${encodeURIComponent(id)}`)
 }
 
 // ---- Saved queries (roadmap §5.5) -------------------------------------------
@@ -758,15 +702,8 @@ export async function updateSavedQuery(
   return savedQuery
 }
 
-export async function deleteSavedQuery(id: string): Promise<void> {
-  const res = await fetch(`/api/saved-queries/${encodeURIComponent(id)}`, {
-    method: 'DELETE',
-    credentials: 'same-origin',
-  })
-  if (!res.ok) {
-    const json = await res.json().catch(() => null)
-    throw parseErrorBody(json, res.status)
-  }
+export function deleteSavedQuery(id: string): Promise<void> {
+  return del(`/api/saved-queries/${encodeURIComponent(id)}`)
 }
 
 export async function importSavedQueries(
@@ -828,26 +765,13 @@ export async function addQueryHistory(payload: AddHistoryPayload): Promise<void>
   })
 }
 
-export async function deleteQueryHistoryEntry(id: string): Promise<void> {
-  const res = await fetch(`/api/query-history/${encodeURIComponent(id)}`, {
-    method: 'DELETE',
-    credentials: 'same-origin',
-  })
-  if (!res.ok) {
-    const json = await res.json().catch(() => null)
-    throw parseErrorBody(json, res.status)
-  }
+export function deleteQueryHistoryEntry(id: string): Promise<void> {
+  return del(`/api/query-history/${encodeURIComponent(id)}`)
 }
 
 export async function clearQueryHistory(connectionId: string): Promise<number> {
   const qs = new URLSearchParams({ connectionId })
-  const res = await fetch(`/api/query-history?${qs.toString()}`, {
-    method: 'DELETE',
-    credentials: 'same-origin',
-  })
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return ClearHistoryResponse.parse(json).count
+  return (await del(`/api/query-history?${qs.toString()}`, ClearHistoryResponse)).count
 }
 
 // ---- Inline row edit --------------------------------------------------------
@@ -866,21 +790,10 @@ export async function updateRow(
   tableName: string,
   payload: UpdateRowPayload,
 ): Promise<Record<string, unknown>> {
-  const res = await fetch(
+  return (await postJson(
     `/api/tables/${encodeURIComponent(tableName)}/rows`,
-    {
-      method: 'PATCH',
-      headers: {
-        'content-type': 'application/json',
-        'x-connection-id': connectionId,
-      },
-      body: JSON.stringify(payload),
-      credentials: 'same-origin',
-    },
-  )
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return UpdateRowResponse.parse(json).row
+    payload, UpdateRowResponse, 'PATCH', connectionId,
+  )).row
 }
 
 // ---- Row insert -------------------------------------------------------------
@@ -900,21 +813,10 @@ export async function insertRow(
   tableName: string,
   payload: InsertRowPayload,
 ): Promise<Record<string, unknown>> {
-  const res = await fetch(
+  return (await postJson(
     `/api/tables/${encodeURIComponent(tableName)}/rows`,
-    {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'x-connection-id': connectionId,
-      },
-      body: JSON.stringify(payload),
-      credentials: 'same-origin',
-    },
-  )
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return InsertRowResponse.parse(json).row
+    payload, InsertRowResponse, 'POST', connectionId,
+  )).row
 }
 
 // ---- CSV import -------------------------------------------------------------
@@ -946,26 +848,15 @@ const ImportResultResponse = z.object({
 })
 export type ImportResult = z.infer<typeof ImportResultResponse>
 
-export async function importTableData(
+export function importTableData(
   connectionId: string,
   tableName: string,
   payload: ImportPayload,
 ): Promise<ImportResult> {
-  const res = await fetch(
+  return postJson(
     `/api/tables/${encodeURIComponent(tableName)}/import`,
-    {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'x-connection-id': connectionId,
-      },
-      body: JSON.stringify(payload),
-      credentials: 'same-origin',
-    },
+    payload, ImportResultResponse, 'POST', connectionId,
   )
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return ImportResultResponse.parse(json)
 }
 
 export function getTableData(
@@ -1143,20 +1034,12 @@ const BackendActionResponse = z.object({
   terminated: z.boolean().optional(),
 })
 
-async function backendAction(
+function backendAction(
   action: 'cancel' | 'terminate',
   connectionId: string,
   pid: number,
 ) {
-  const res = await fetch(`/api/operations/${action}`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'x-connection-id': connectionId },
-    body: JSON.stringify({ pid }),
-    credentials: 'same-origin',
-  })
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return BackendActionResponse.parse(json)
+  return postJson(`/api/operations/${action}`, { pid }, BackendActionResponse, 'POST', connectionId)
 }
 
 /** Cancel the running query on a backend (gentle — keeps the session). */
@@ -1232,15 +1115,9 @@ const StatementActionResponse = z.object({
 })
 export type StatementActionResult = z.infer<typeof StatementActionResponse>
 
-async function statementsAction(action: 'enable' | 'reset', connectionId: string) {
-  const res = await fetch(`/api/operations/statements/${action}`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'x-connection-id': connectionId },
-    credentials: 'same-origin',
-  })
-  const json = await res.json().catch(() => null)
-  if (!res.ok) throw parseErrorBody(json, res.status)
-  return StatementActionResponse.parse(json)
+function statementsAction(action: 'enable' | 'reset', connectionId: string) {
+  return postJson(`/api/operations/statements/${action}`, {},
+    StatementActionResponse, 'POST', connectionId)
 }
 
 /** Create pg_stat_statements (idempotent; needs a privileged role). */
@@ -1303,4 +1180,81 @@ export type IndexAdvice = z.infer<typeof IndexAdviceSchema>
 
 export function getIndexAdvice(connectionId: string, signal?: AbortSignal) {
   return api('/api/operations/indexes', IndexAdviceSchema, { connectionId, signal })
+}
+
+// ---- Schema diff & migration generator (roadmap §7.1) -----------------------
+
+// One generated migration statement. `destructive` (DROP / column-type change)
+// is flagged so the UI can render it red; nothing is run for the user — the SQL
+// goes to the editor behind the Run button, like the index assistant's DDL.
+const MigrationStatementSchema = z.object({
+  sql: z.string(),
+  destructive: z.boolean(),
+  kind: z.string(),
+})
+export type MigrationStatement = z.infer<typeof MigrationStatementSchema>
+
+const MigrationSchema = z.object({
+  statements: z.array(MigrationStatementSchema),
+  hasDestructive: z.boolean(),
+})
+export type Migration = z.infer<typeof MigrationSchema>
+
+const ColumnSnapshotSchema = z.object({
+  name: z.string(),
+  ordinal: z.number(),
+  type: z.string(),
+  notNull: z.boolean(),
+  default: z.string().nullable(),
+})
+export type ColumnSnapshot = z.infer<typeof ColumnSnapshotSchema>
+
+// An added/dropped constraint or index carries its name + Postgres-rendered def.
+const NamedObjectSchema = z.object({
+  name: z.string(),
+  definition: z.string(),
+  contype: z.string().optional(),
+})
+const NamedChangeSchema = z.object({
+  name: z.string(),
+  from: z.object({ definition: z.string(), contype: z.string().optional() }),
+  to: z.object({ definition: z.string(), contype: z.string().optional() }),
+})
+const NamedDiffSchema = z.object({
+  added: z.array(NamedObjectSchema),
+  dropped: z.array(NamedObjectSchema),
+  changed: z.array(NamedChangeSchema),
+})
+
+const TableChangeSchema = z.object({
+  table: z.string(),
+  columns: z.object({
+    added: z.array(ColumnSnapshotSchema),
+    dropped: z.array(ColumnSnapshotSchema),
+    changed: z.array(z.object({
+      name: z.string(),
+      from: ColumnSnapshotSchema,
+      to: ColumnSnapshotSchema,
+    })),
+  }),
+  constraints: NamedDiffSchema,
+  indexes: NamedDiffSchema,
+})
+export type TableChange = z.infer<typeof TableChangeSchema>
+
+const SchemaDiffResponseSchema = z.object({
+  source: z.object({ connectionId: z.string(), schema: z.string() }),
+  target: z.object({ connectionId: z.string(), schema: z.string() }),
+  diff: z.object({
+    tables: z.object({ added: z.array(z.string()), dropped: z.array(z.string()) }),
+    changed: z.array(TableChangeSchema),
+  }),
+  forward: MigrationSchema,
+  backward: MigrationSchema,
+})
+export type SchemaDiffResponse = z.infer<typeof SchemaDiffResponseSchema>
+
+export function getSchemaDiff(source: string, target: string, signal?: AbortSignal) {
+  const qs = new URLSearchParams({ source, target })
+  return api(`/api/schema-diff?${qs.toString()}`, SchemaDiffResponseSchema, { signal })
 }

--- a/client-next/src/lib/clipboard.ts
+++ b/client-next/src/lib/clipboard.ts
@@ -1,0 +1,9 @@
+/** Copy `text` to the clipboard. Returns whether it succeeded. */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/client-next/src/lib/download.ts
+++ b/client-next/src/lib/download.ts
@@ -1,0 +1,20 @@
+/**
+ * Trigger a browser file download. Accepts a ready Blob or a string (wrapped in
+ * a Blob with the given mime). One place for the create-anchor-click-revoke
+ * dance every export path needs.
+ */
+export function downloadBlob(
+  content: string | Blob,
+  fileName: string,
+  mime = 'application/octet-stream',
+) {
+  const blob = typeof content === 'string' ? new Blob([content], { type: mime }) : content
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = fileName
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}

--- a/client-next/src/lib/resultExport.ts
+++ b/client-next/src/lib/resultExport.ts
@@ -6,6 +6,8 @@
  * fit and needs no extra round-trip.
  */
 
+import { downloadBlob } from '@/lib/download'
+
 export type ResultExportFormat = 'csv' | 'json'
 
 type Row = Record<string, unknown>
@@ -39,18 +41,6 @@ const MIME: Record<ResultExportFormat, string> = {
   json: 'application/json',
 }
 
-function triggerDownload(text: string, fileName: string, mime: string) {
-  const blob = new Blob([text], { type: mime })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = fileName
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
-
 /** Serialize and download the active result set in `format`. */
 export function downloadResult(
   format: ResultExportFormat,
@@ -60,5 +50,5 @@ export function downloadResult(
 ) {
   const text =
     format === 'csv' ? resultToCsv(columns, rows) : resultToJson(rows)
-  triggerDownload(text, `${baseName}.${format}`, MIME[format])
+  downloadBlob(text, `${baseName}.${format}`, MIME[format])
 }

--- a/client-next/src/pages/IndexAssistant.tsx
+++ b/client-next/src/pages/IndexAssistant.tsx
@@ -1,12 +1,12 @@
-import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import {
-  AlertTriangle, Copy as CopyIcon, Database, FileSearch, Layers,
+  AlertTriangle, Database, FileSearch, Layers,
   Play, RefreshCw, Table as TableIcon, Trash2,
 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
+import { CopyButton } from '@/components/CopyButton'
 import { Loading, Spinner } from '@/components/ui/spinner'
 import {
   getIndexAdvice,
@@ -99,22 +99,6 @@ function useOpenInEditor() {
   }
 }
 
-function CopyButton({ text, label = 'Copy DDL' }: { text: string; label?: string }) {
-  const [copied, setCopied] = useState(false)
-  const copy = () => {
-    void navigator.clipboard?.writeText(text).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    })
-  }
-  return (
-    <Button size="sm" variant="ghost" className="h-7" onClick={copy}>
-      <CopyIcon className="h-3.5 w-3.5" />
-      {copied ? 'Copied' : label}
-    </Button>
-  )
-}
-
 // ---- Panels -----------------------------------------------------------------
 
 function Panel({
@@ -191,7 +175,7 @@ function UnusedPanel({ section }: { section: { data: UnusedIndex[] | null; error
                   <span className="whitespace-nowrap text-xs tabular-nums text-muted-foreground">
                     {formatBytes(ix.size_bytes)}
                   </span>
-                  <CopyButton text={ix.drop_ddl} />
+                  <CopyButton text={ix.drop_ddl} label="Copy DDL" />
                   <Button
                     size="sm"
                     variant="outline"
@@ -253,7 +237,7 @@ function DuplicatePanel({ section }: { section: { data: DuplicateGroup[] | null;
                       <span className="whitespace-nowrap text-xs tabular-nums text-muted-foreground">
                         {formatBytes(ix.size_bytes)}
                       </span>
-                      <CopyButton text={ix.drop_ddl} />
+                      <CopyButton text={ix.drop_ddl} label="Copy DDL" />
                       <Button
                         size="sm"
                         variant="outline"

--- a/client-next/src/pages/SchemaDiff.tsx
+++ b/client-next/src/pages/SchemaDiff.tsx
@@ -1,0 +1,356 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import {
+  AlertTriangle, ArrowRight, Download, GitCompare,
+  Minus, Pencil, Play, Plus, RefreshCw,
+} from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { CopyButton } from '@/components/CopyButton'
+import { Select } from '@/components/ui/select'
+import { Loading, Spinner } from '@/components/ui/spinner'
+import {
+  getSchemaDiff, listConnections,
+  type Connection, type Migration, type SchemaDiffResponse, type TableChange,
+} from '@/lib/api'
+import { downloadBlob } from '@/lib/download'
+import { cn } from '@/lib/utils'
+import { useConnectionStore } from '@/store/connection'
+import { useQuerySeedStore } from '@/store/querySeed'
+import { useTabsStore } from '@/store/tabs'
+
+export function SchemaDiff() {
+  const activeId = useConnectionStore((s) => s.activeConnectionId)
+
+  const connections = useQuery({
+    queryKey: ['connections'],
+    queryFn: ({ signal }) => listConnections(signal).then((r) => r.connections),
+  })
+  const conns = connections.data ?? []
+
+  const [source, setSource] = useState<string>('')
+  const [target, setTarget] = useState<string>('')
+
+  // Default source → active connection, target → first other connection.
+  const resolvedSource = source || activeId || conns[0]?.id || ''
+  const resolvedTarget =
+    target || conns.find((c) => c.id !== resolvedSource)?.id || ''
+
+  const ready = !!resolvedSource && !!resolvedTarget && resolvedSource !== resolvedTarget
+
+  const diff = useQuery({
+    queryKey: ['schema-diff', resolvedSource, resolvedTarget],
+    queryFn: ({ signal }) => getSchemaDiff(resolvedSource, resolvedTarget, signal),
+    enabled: ready,
+    placeholderData: (prev) => prev,
+  })
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="flex items-center justify-between gap-4 border-b border-border px-6 py-3">
+        <div className="min-w-0">
+          <h1 className="text-lg font-semibold">Schema diff &amp; migration</h1>
+          <p className="text-xs text-muted-foreground">
+            Compare two connections · generated SQL is never run for you
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => diff.refetch()}
+          disabled={!ready || diff.isFetching}
+          title="Re-compare"
+        >
+          {diff.isFetching ? <Spinner aria-label="Comparing" /> : <RefreshCw className="h-3.5 w-3.5" />}
+          Re-compare
+        </Button>
+      </header>
+
+      {/* Connection pickers */}
+      <div className="flex flex-wrap items-end gap-3 border-b border-border px-6 py-3">
+        <ConnPicker label="Source (current)" value={resolvedSource} conns={conns} onChange={setSource} />
+        <ArrowRight className="mb-2 h-4 w-4 text-muted-foreground" />
+        <ConnPicker label="Target (desired)" value={resolvedTarget} conns={conns} onChange={setTarget} />
+        <p className="mb-2 ml-2 text-[11px] text-muted-foreground">
+          Forward migration makes <strong>source</strong> match <strong>target</strong>.
+        </p>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto px-6 py-4">
+        {conns.length < 2 && (
+          <Empty>Add at least two connections to diff their schemas.</Empty>
+        )}
+        {ready && diff.isLoading && (
+          <div className="py-10 text-center text-sm text-muted-foreground">
+            <Loading>Comparing schemas…</Loading>
+          </div>
+        )}
+        {diff.error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {(diff.error as Error).message}
+          </div>
+        )}
+        {diff.data && <DiffResult data={diff.data} />}
+      </div>
+    </div>
+  )
+}
+
+function ConnPicker({
+  label, value, conns, onChange,
+}: {
+  label: string
+  value: string
+  conns: Connection[]
+  onChange: (id: string) => void
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </span>
+      <Select value={value} onChange={(e) => onChange(e.target.value)} className="w-56">
+        {conns.map((c) => (
+          <option key={c.id} value={c.id}>
+            {(c.name || c.id)} · {c.schema ?? 'public'}
+          </option>
+        ))}
+      </Select>
+    </label>
+  )
+}
+
+function DiffResult({ data }: { data: SchemaDiffResponse }) {
+  const { diff } = data
+  const noChanges =
+    diff.tables.added.length === 0 &&
+    diff.tables.dropped.length === 0 &&
+    diff.changed.length === 0
+
+  if (noChanges) {
+    return <Empty>Schemas are identical. 🎉</Empty>
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2 text-xs">
+        <Stat tone="add" label="tables added" n={diff.tables.added.length} />
+        <Stat tone="drop" label="tables dropped" n={diff.tables.dropped.length} />
+        <Stat tone="change" label="tables changed" n={diff.changed.length} />
+      </div>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <DiffPanel data={data} />
+        <MigrationPanel data={data} />
+      </section>
+    </div>
+  )
+}
+
+// ---- Diff panel -------------------------------------------------------------
+
+function DiffPanel({ data }: { data: SchemaDiffResponse }) {
+  const { diff } = data
+  return (
+    <Panel title="Changes" icon={GitCompare}>
+      <div className="space-y-1 px-4 py-3 text-sm">
+        {diff.tables.added.map((t) => (
+          <Line key={`a-${t}`} tone="add" icon={Plus}>
+            <code className="font-mono">{t}</code> <span className="text-muted-foreground">(new table)</span>
+          </Line>
+        ))}
+        {diff.tables.dropped.map((t) => (
+          <Line key={`d-${t}`} tone="drop" icon={Minus}>
+            <code className="font-mono">{t}</code> <span className="text-muted-foreground">(dropped table)</span>
+          </Line>
+        ))}
+        {diff.changed.map((ch) => (
+          <TableChangeBlock key={ch.table} ch={ch} />
+        ))}
+      </div>
+    </Panel>
+  )
+}
+
+function TableChangeBlock({ ch }: { ch: TableChange }) {
+  return (
+    <div className="mt-2 border-l-2 border-amber-400/50 pl-3">
+      <div className="flex items-center gap-2">
+        <Pencil className="h-3.5 w-3.5 text-amber-500" />
+        <code className="font-mono text-sm">{ch.table}</code>
+      </div>
+      <ul className="mt-1 space-y-0.5 pl-5 text-xs">
+        {ch.columns.added.map((c) => (
+          <Sub key={`ca-${c.name}`} tone="add">+ column {c.name} {c.type}</Sub>
+        ))}
+        {ch.columns.changed.map((c) => (
+          <Sub key={`cc-${c.name}`} tone="change">
+            ~ column {c.name}: {c.from.type} → {c.to.type}
+            {c.from.notNull !== c.to.notNull && (c.to.notNull ? ' · SET NOT NULL' : ' · DROP NOT NULL')}
+          </Sub>
+        ))}
+        {ch.columns.dropped.map((c) => (
+          <Sub key={`cd-${c.name}`} tone="drop">− column {c.name}</Sub>
+        ))}
+        {ch.constraints.added.map((c) => <Sub key={`xa-${c.name}`} tone="add">+ constraint {c.name}</Sub>)}
+        {ch.constraints.changed.map((c) => <Sub key={`xc-${c.name}`} tone="change">~ constraint {c.name}</Sub>)}
+        {ch.constraints.dropped.map((c) => <Sub key={`xd-${c.name}`} tone="drop">− constraint {c.name}</Sub>)}
+        {ch.indexes.added.map((c) => <Sub key={`ia-${c.name}`} tone="add">+ index {c.name}</Sub>)}
+        {ch.indexes.changed.map((c) => <Sub key={`ic-${c.name}`} tone="change">~ index {c.name}</Sub>)}
+        {ch.indexes.dropped.map((c) => <Sub key={`id-${c.name}`} tone="drop">− index {c.name}</Sub>)}
+      </ul>
+    </div>
+  )
+}
+
+// ---- Migration panel --------------------------------------------------------
+
+function MigrationPanel({ data }: { data: SchemaDiffResponse }) {
+  const [dir, setDir] = useState<'forward' | 'backward'>('forward')
+  const migration: Migration = dir === 'forward' ? data.forward : data.backward
+  // The migration runs against the side it transforms: forward → source, backward → target.
+  const runAgainst = dir === 'forward' ? data.source : data.target
+
+  const script = useMemo(
+    () => migration.statements.map((s) => s.sql).join('\n'),
+    [migration],
+  )
+
+  const navigate = useNavigate()
+  const openTab = useTabsStore((s) => s.open)
+  const setActive = useConnectionStore((s) => s.setActive)
+  const openInEditor = () => {
+    // Switch the editor to the connection this migration is meant to run against,
+    // seed the SQL, and jump there — the user reviews and runs it.
+    setActive(runAgainst.connectionId)
+    useQuerySeedStore.getState().setSeed(script)
+    openTab({ kind: 'query' })
+    navigate({ to: '/query' })
+  }
+
+  const download = () => downloadBlob(script, `migration_${dir}.sql`, 'application/sql')
+
+  return (
+    <Panel
+      title="Migration"
+      icon={Play}
+      action={
+        <div className="flex rounded-md border border-border p-0.5">
+          {(['forward', 'backward'] as const).map((d) => (
+            <button
+              key={d}
+              onClick={() => setDir(d)}
+              className={cn(
+                'rounded px-2 py-0.5 text-xs',
+                dir === d ? 'bg-accent text-accent-foreground' : 'text-muted-foreground',
+              )}
+            >
+              {d === 'forward' ? 'Forward' : 'Backward'}
+            </button>
+          ))}
+        </div>
+      }
+    >
+      <div className="flex flex-col">
+        <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2 text-xs text-muted-foreground">
+          <span>
+            runs against <code className="font-mono">{runAgainst.connectionId.slice(0, 8)}</code> · {runAgainst.schema}
+          </span>
+          <div className="flex items-center gap-1">
+            <CopyButton text={script} />
+            <Button size="sm" variant="ghost" className="h-7" onClick={download} disabled={!script}>
+              <Download className="h-3.5 w-3.5" />Download
+            </Button>
+            <Button size="sm" variant="outline" className="h-7" onClick={openInEditor} disabled={!script}>
+              <Play className="h-3.5 w-3.5" />Open in editor
+            </Button>
+          </div>
+        </div>
+
+        {migration.hasDestructive && (
+          <div className="flex items-start gap-2 border-b border-border bg-destructive/10 px-4 py-2 text-xs text-destructive">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>Contains destructive operations (highlighted) — review before running.</span>
+          </div>
+        )}
+
+        {migration.statements.length === 0 ? (
+          <Empty>No statements for this direction.</Empty>
+        ) : (
+          <pre className="max-h-[28rem] overflow-auto px-4 py-3 text-xs leading-relaxed">
+            {migration.statements.map((s, i) => (
+              <div
+                key={i}
+                className={cn('whitespace-pre-wrap font-mono', s.destructive && 'text-destructive')}
+                title={s.destructive ? 'destructive operation' : undefined}
+              >
+                {s.sql}
+              </div>
+            ))}
+          </pre>
+        )}
+      </div>
+    </Panel>
+  )
+}
+
+// ---- Small shared bits ------------------------------------------------------
+
+function Panel({
+  title, icon: Icon, action, children,
+}: {
+  title: string
+  icon: React.ComponentType<{ className?: string }>
+  action?: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <section className="flex flex-col overflow-hidden rounded-lg border border-border bg-card">
+      <header className="flex items-center gap-2 border-b border-border px-4 py-2.5">
+        <Icon className="h-4 w-4 text-muted-foreground" />
+        <h2 className="text-sm font-semibold">{title}</h2>
+        {action && <div className="ml-auto">{action}</div>}
+      </header>
+      <div className="min-h-0 flex-1">{children}</div>
+    </section>
+  )
+}
+
+const TONE: Record<string, string> = {
+  add: 'text-emerald-600 dark:text-emerald-400',
+  drop: 'text-destructive',
+  change: 'text-amber-600 dark:text-amber-400',
+}
+
+function Stat({ tone, label, n }: { tone: keyof typeof TONE; label: string; n: number }) {
+  return (
+    <span className="rounded-md border border-border bg-card px-2 py-1">
+      <span className={cn('font-semibold tabular-nums', TONE[tone])}>{n}</span>{' '}
+      <span className="text-muted-foreground">{label}</span>
+    </span>
+  )
+}
+
+function Line({
+  tone, icon: Icon, children,
+}: {
+  tone: keyof typeof TONE
+  icon: React.ComponentType<{ className?: string }>
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className={cn('h-3.5 w-3.5 shrink-0', TONE[tone])} />
+      <span>{children}</span>
+    </div>
+  )
+}
+
+function Sub({ tone, children }: { tone: keyof typeof TONE; children: React.ReactNode }) {
+  return <li className={cn('font-mono', TONE[tone])}>{children}</li>
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return <p className="px-4 py-10 text-center text-sm text-muted-foreground">{children}</p>
+}

--- a/client-next/src/pages/SchemaViz.tsx
+++ b/client-next/src/pages/SchemaViz.tsx
@@ -28,6 +28,8 @@ import { Input } from '@/components/ui/input'
 import { Dropdown, DropdownItem } from '@/components/ui/dropdown'
 import { Loading } from '@/components/ui/spinner'
 import { getDatabaseSchema, type SchemaTable } from '@/lib/api'
+import { copyText } from '@/lib/clipboard'
+import { downloadBlob } from '@/lib/download'
 import { toMermaidER } from '@/lib/mermaid'
 import { useConnectionStore } from '@/store/connection'
 import { useEffectiveTheme } from '@/store/theme'
@@ -159,28 +161,6 @@ function buildEdges(tables: SchemaTable[]): Edge[] {
   return edges
 }
 
-function downloadBlob(content: string | Blob, fileName: string, mime?: string) {
-  const blob =
-    typeof content === 'string' ? new Blob([content], { type: mime ?? 'text/plain' }) : content
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = fileName
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
-
-async function copyToClipboard(text: string): Promise<boolean> {
-  try {
-    await navigator.clipboard.writeText(text)
-    return true
-  } catch {
-    return false
-  }
-}
-
 function SchemaCanvas({ tables }: { tables: SchemaTable[] }) {
   const [filter, setFilter] = useState('')
   const [hoveredId, setHoveredId] = useState<string | null>(null)
@@ -270,7 +250,7 @@ function SchemaCanvas({ tables }: { tables: SchemaTable[] }) {
   const mermaidText = useMemo(() => toMermaidER(filteredTables), [filteredTables])
 
   const copyMermaid = useCallback(async () => {
-    const ok = await copyToClipboard(mermaidText)
+    const ok = await copyText(mermaidText)
     if (ok) {
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)

--- a/client-next/src/routeTree.tsx
+++ b/client-next/src/routeTree.tsx
@@ -6,6 +6,7 @@ import { QueryRunner } from './pages/QueryRunner'
 import { Operations } from './pages/Operations'
 import { SlowQueries } from './pages/SlowQueries'
 import { IndexAssistant } from './pages/IndexAssistant'
+import { SchemaDiff } from './pages/SchemaDiff'
 import { Sidebar } from './components/Sidebar'
 import { TabBar } from './components/TabBar'
 import { Spotlight } from './components/Spotlight'
@@ -90,6 +91,12 @@ const indexAssistantRoute = createRoute({
   component: IndexAssistant,
 })
 
+const schemaDiffRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/schema-diff',
+  component: SchemaDiff,
+})
+
 export const routeTree = rootRoute.addChildren([
   homeRoute,
   tableRoute,
@@ -98,4 +105,5 @@ export const routeTree = rootRoute.addChildren([
   operationsRoute,
   slowQueriesRoute,
   indexAssistantRoute,
+  schemaDiffRoute,
 ])

--- a/client-next/src/store/tabs.ts
+++ b/client-next/src/store/tabs.ts
@@ -7,6 +7,7 @@ export type Tab =
   | { kind: 'operations' }
   | { kind: 'slow-queries' }
   | { kind: 'index-assistant' }
+  | { kind: 'schema-diff' }
   | { kind: 'home' }
 
 function tabId(t: Tab): string {
@@ -17,6 +18,7 @@ function tabId(t: Tab): string {
     case 'operations': return 'operations'
     case 'slow-queries': return 'slow-queries'
     case 'index-assistant': return 'index-assistant'
+    case 'schema-diff': return 'schema-diff'
     case 'home': return 'home'
   }
 }
@@ -29,6 +31,7 @@ function tabLabel(t: Tab): string {
     case 'operations': return 'Operations'
     case 'slow-queries': return 'Slow queries'
     case 'index-assistant': return 'Index assistant'
+    case 'schema-diff': return 'Schema diff'
     case 'home': return 'Home'
   }
 }
@@ -41,6 +44,7 @@ function tabRoute(t: Tab): string {
     case 'operations': return '/operations'
     case 'slow-queries': return '/slow-queries'
     case 'index-assistant': return '/index-assistant'
+    case 'schema-diff': return '/schema-diff'
     case 'home': return '/'
   }
 }

--- a/src/db/schemaDiff.js
+++ b/src/db/schemaDiff.js
@@ -1,0 +1,370 @@
+/**
+ * Schema diff & migration generator (roadmap §7.1).
+ *
+ * Introspect two schemas into normalized snapshots, diff them, and generate an
+ * idempotent-ish migration that transforms one into the other (plus its
+ * reverse). Like the index assistant, nothing here ever runs the migration: the
+ * generated SQL is handed to the user to review and run in the editor, so every
+ * destructive operation stays behind the editor's Run button.
+ *
+ * Three pieces:
+ *   - introspectSchema(pool, schema)  — the only DB-touching part. Reads tables,
+ *     columns, constraints, and (non-constraint) indexes from the catalogs,
+ *     letting Postgres render constraint/index DDL via pg_get_*def().
+ *   - diffSchemas(from, to)           — pure. Structured diff for the viewer.
+ *   - buildMigration(from, to)        — pure. Ordered statement list (with a
+ *     `destructive` flag per statement) to turn `from` into `to`. The reverse
+ *     migration is just buildMigration(to, from) — same code, args swapped.
+ *
+ * ponytail: the .sql-baseline-file side of the roadmap (diff a live DB against a
+ * dump) is skipped — it needs a real DDL parser to build a snapshot from text.
+ * Both sides here are live connections (prod-vs-staging, the common case). Add
+ * the file baseline when a parser is on hand. The migration also assumes both
+ * sides use the same schema *name* (so pg_get_*def() output lines up); cross-
+ * schema renames are out of scope — note it in the header comment, don't parse.
+ */
+
+const { quoteIdent, quoteQualifiedIdent } = require('./identifier');
+
+// --- Introspection (the only part that touches the database) ----------------
+
+const TABLES_SQL = `
+  SELECT c.relname AS table_name
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = $1
+     AND c.relkind IN ('r', 'p')
+   ORDER BY c.relname`;
+
+// format_type() gives the faithful type (e.g. numeric(10,2), varchar(255),
+// int4[]) — more accurate than information_schema for diffing.
+const COLUMNS_SQL = `
+  SELECT c.relname                              AS table_name,
+         a.attname                              AS column_name,
+         a.attnum                               AS ordinal,
+         format_type(a.atttypid, a.atttypmod)   AS data_type,
+         a.attnotnull                           AS not_null,
+         pg_get_expr(d.adbin, d.adrelid)        AS default_expr
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_attribute a ON a.attrelid = c.oid
+    LEFT JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = a.attnum
+   WHERE n.nspname = $1
+     AND c.relkind IN ('r', 'p')
+     AND a.attnum > 0
+     AND NOT a.attisdropped
+   ORDER BY c.relname, a.attnum`;
+
+// All constraints, with Postgres-rendered DDL. contype: p=PK f=FK u=unique
+// c=check x=exclusion. FKs are emitted last in the migration (see ordering).
+const CONSTRAINTS_SQL = `
+  SELECT c.relname                     AS table_name,
+         con.conname                   AS constraint_name,
+         con.contype::text             AS contype,
+         pg_get_constraintdef(con.oid) AS definition
+    FROM pg_constraint con
+    JOIN pg_class c     ON c.oid = con.conrelid
+    JOIN pg_namespace n ON n.oid = con.connamespace
+   WHERE n.nspname = $1
+     AND c.relkind IN ('r', 'p')
+   ORDER BY c.relname, con.conname`;
+
+// Only indexes NOT backing a constraint — PK/unique indexes are handled through
+// the constraint section, so excluding them here avoids emitting both.
+const INDEXES_SQL = `
+  SELECT c.relname                      AS table_name,
+         ic.relname                     AS index_name,
+         pg_get_indexdef(i.indexrelid)  AS definition
+    FROM pg_index i
+    JOIN pg_class ic    ON ic.oid = i.indexrelid
+    JOIN pg_class c     ON c.oid = i.indrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = $1
+     AND c.relkind IN ('r', 'p')
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint con WHERE con.conindid = i.indexrelid)
+   ORDER BY c.relname, ic.relname`;
+
+/**
+ * Read one schema into a normalized snapshot:
+ *   { schema, tables: { [name]: { columns: [...ordered], constraints: {}, indexes: {} } } }
+ * Columns stay an ordered array (for CREATE TABLE); constraints/indexes are
+ * keyed by name (for by-name diffing).
+ */
+async function introspectSchema(pool, schema) {
+  const [tables, columns, constraints, indexes] = await Promise.all([
+    pool.query(TABLES_SQL, [schema]),
+    pool.query(COLUMNS_SQL, [schema]),
+    pool.query(CONSTRAINTS_SQL, [schema]),
+    pool.query(INDEXES_SQL, [schema]),
+  ]);
+
+  const snapshot = { schema, tables: {} };
+  const table = (name) =>
+    (snapshot.tables[name] ??= { columns: [], constraints: {}, indexes: {} });
+
+  for (const r of tables.rows) table(r.table_name);
+  for (const r of columns.rows) {
+    // A column on a table not seen in TABLES_SQL can't happen, but guard anyway.
+    table(r.table_name).columns.push({
+      name: r.column_name,
+      ordinal: Number(r.ordinal),
+      type: r.data_type,
+      notNull: r.not_null === true || r.not_null === 't',
+      default: r.default_expr ?? null,
+    });
+  }
+  for (const r of constraints.rows) {
+    table(r.table_name).constraints[r.constraint_name] = {
+      contype: r.contype,
+      definition: r.definition,
+    };
+  }
+  for (const r of indexes.rows) {
+    table(r.table_name).indexes[r.index_name] = { definition: r.definition };
+  }
+  return snapshot;
+}
+
+// --- Pure diff --------------------------------------------------------------
+
+function colByName(table) {
+  const out = {};
+  for (const c of table.columns) out[c.name] = c;
+  return out;
+}
+
+function columnChanged(a, b) {
+  return a.type !== b.type || a.notNull !== b.notNull || a.default !== b.default;
+}
+
+/** Diff one table's columns/constraints/indexes. Returns null if identical. */
+function diffTable(from, to) {
+  const fromCols = colByName(from);
+  const toCols = colByName(to);
+
+  const columns = { added: [], dropped: [], changed: [] };
+  for (const c of to.columns) {
+    if (!fromCols[c.name]) columns.added.push(c);
+    else if (columnChanged(fromCols[c.name], c)) {
+      columns.changed.push({ name: c.name, from: fromCols[c.name], to: c });
+    }
+  }
+  for (const c of from.columns) {
+    if (!toCols[c.name]) columns.dropped.push(c);
+  }
+
+  const diffNamed = (fromMap, toMap) => {
+    const added = [], dropped = [], changed = [];
+    for (const name of Object.keys(toMap)) {
+      if (!fromMap[name]) added.push({ name, ...toMap[name] });
+      else if (fromMap[name].definition !== toMap[name].definition) {
+        changed.push({ name, from: fromMap[name], to: toMap[name] });
+      }
+    }
+    for (const name of Object.keys(fromMap)) {
+      if (!toMap[name]) dropped.push({ name, ...fromMap[name] });
+    }
+    return { added, dropped, changed };
+  };
+
+  const constraints = diffNamed(from.constraints, to.constraints);
+  const indexes = diffNamed(from.indexes, to.indexes);
+
+  const empty = (d) => d.added.length === 0 && d.dropped.length === 0 && d.changed.length === 0;
+  if (empty(columns) && empty(constraints) && empty(indexes)) return null;
+  return { columns, constraints, indexes };
+}
+
+/**
+ * Structured diff for the side-by-side viewer. `tables.added` are in `to` only,
+ * `tables.dropped` in `from` only, and `changed` is one entry per table present
+ * in both that differs.
+ */
+function diffSchemas(from, to) {
+  const fromNames = Object.keys(from.tables);
+  const toNames = Object.keys(to.tables);
+  const fromSet = new Set(fromNames);
+  const toSet = new Set(toNames);
+
+  const added = toNames.filter((n) => !fromSet.has(n)).sort();
+  const dropped = fromNames.filter((n) => !toSet.has(n)).sort();
+
+  const changed = [];
+  for (const name of toNames.filter((n) => fromSet.has(n)).sort()) {
+    const d = diffTable(from.tables[name], to.tables[name]);
+    if (d) changed.push({ table: name, ...d });
+  }
+  return { tables: { added, dropped }, changed };
+}
+
+// --- Pure migration builder -------------------------------------------------
+
+function columnDef(schema, table, col) {
+  let def = `${quoteIdent(col.name)} ${col.type}`;
+  if (col.notNull) def += ' NOT NULL';
+  if (col.default != null) def += ` DEFAULT ${col.default}`;
+  return def;
+}
+
+function createTableSql(schema, name, table) {
+  const cols = table.columns.map((c) => `  ${columnDef(schema, name, c)}`).join(',\n');
+  return `CREATE TABLE ${quoteQualifiedIdent(schema, name)} (\n${cols}\n);`;
+}
+
+// ALTER statements to turn column `from` into `to` (type/null/default).
+function alterColumnSql(schema, table, from, to) {
+  const t = quoteQualifiedIdent(schema, table);
+  const col = quoteIdent(to.name);
+  const out = [];
+  if (from.type !== to.type) {
+    // Type changes can be lossy/rewrite the table — always flagged destructive.
+    out.push({ sql: `ALTER TABLE ${t} ALTER COLUMN ${col} TYPE ${to.type};`, destructive: true, kind: 'alter_column_type' });
+  }
+  if (from.notNull !== to.notNull) {
+    out.push({
+      sql: `ALTER TABLE ${t} ALTER COLUMN ${col} ${to.notNull ? 'SET' : 'DROP'} NOT NULL;`,
+      destructive: false, kind: 'alter_column_null',
+    });
+  }
+  if (from.default !== to.default) {
+    out.push({
+      sql: to.default != null
+        ? `ALTER TABLE ${t} ALTER COLUMN ${col} SET DEFAULT ${to.default};`
+        : `ALTER TABLE ${t} ALTER COLUMN ${col} DROP DEFAULT;`,
+      destructive: false, kind: 'alter_column_default',
+    });
+  }
+  return out;
+}
+
+const isFk = (c) => c.contype === 'f';
+
+/**
+ * Ordered statement list transforming `from` into `to`. Each statement carries a
+ * `destructive` flag (DROP TABLE/COLUMN/CONSTRAINT/INDEX and column-type changes)
+ * so the UI can flag it red and the user can review before running.
+ *
+ * Order is dependency-aware enough for the common cases: create tables and add
+ * columns before touching them; drop foreign keys and indexes before dropping
+ * the columns/tables under them; add non-FK constraints before FKs; drop columns
+ * and tables last.
+ *
+ * ponytail: this does NOT topologically sort the FK graph (e.g. a chain of new
+ * tables referencing each other added in the wrong order). Nothing here is
+ * executed — the user reviews and reorders in the editor if Postgres complains.
+ * Upgrade to a real dependency sort if that proves common.
+ */
+function buildMigration(from, to) {
+  const diff = diffSchemas(from, to);
+  const schema = from.schema;
+
+  const create = [];          // 1. CREATE TABLE (new tables, columns only)
+  const addColumn = [];       // 2. ADD COLUMN
+  const alterColumn = [];     // 3. ALTER COLUMN
+  const dropConstraint = [];  // 4. DROP CONSTRAINT
+  const dropIndex = [];       // 5. DROP INDEX
+  const addConstraint = [];   // 6. ADD CONSTRAINT (non-FK)
+  const addFk = [];           // 6b. ADD CONSTRAINT (FK, after non-FK)
+  const createIndex = [];     // 7. CREATE INDEX
+  const dropColumn = [];      // 8. DROP COLUMN (destructive)
+  const dropTable = [];       // 9. DROP TABLE (destructive)
+
+  const addConstraintStmt = (table, name, c) => {
+    const stmt = {
+      sql: `ALTER TABLE ${quoteQualifiedIdent(schema, table)} ADD CONSTRAINT ${quoteIdent(name)} ${c.definition};`,
+      destructive: false,
+      kind: 'add_constraint',
+    };
+    (isFk(c) ? addFk : addConstraint).push(stmt);
+  };
+  const dropConstraintStmt = (table, name) => {
+    dropConstraint.push({
+      sql: `ALTER TABLE ${quoteQualifiedIdent(schema, table)} DROP CONSTRAINT ${quoteIdent(name)};`,
+      destructive: true,
+      kind: 'drop_constraint',
+    });
+  };
+
+  // New tables: CREATE, then all their constraints + indexes.
+  for (const name of diff.tables.added) {
+    const t = to.tables[name];
+    create.push({ sql: createTableSql(schema, name, t), destructive: false, kind: 'create_table' });
+    for (const [cname, c] of Object.entries(t.constraints)) addConstraintStmt(name, cname, c);
+    for (const ix of Object.values(t.indexes)) {
+      createIndex.push({ sql: ensureSemicolon(ix.definition), destructive: false, kind: 'create_index' });
+    }
+  }
+
+  // Dropped tables.
+  for (const name of diff.tables.dropped) {
+    dropTable.push({
+      sql: `DROP TABLE ${quoteQualifiedIdent(schema, name)};`,
+      destructive: true,
+      kind: 'drop_table',
+    });
+  }
+
+  // Changed tables.
+  for (const ch of diff.changed) {
+    const t = ch.table;
+    for (const c of ch.columns.added) {
+      addColumn.push({
+        sql: `ALTER TABLE ${quoteQualifiedIdent(schema, t)} ADD COLUMN ${columnDef(schema, t, c)};`,
+        destructive: false, kind: 'add_column',
+      });
+    }
+    for (const c of ch.columns.changed) {
+      alterColumn.push(...alterColumnSql(schema, t, c.from, c.to));
+    }
+    for (const c of ch.columns.dropped) {
+      dropColumn.push({
+        sql: `ALTER TABLE ${quoteQualifiedIdent(schema, t)} DROP COLUMN ${quoteIdent(c.name)};`,
+        destructive: true, kind: 'drop_column',
+      });
+    }
+
+    // Constraints: a changed constraint is drop + re-add.
+    for (const c of ch.constraints.dropped) dropConstraintStmt(t, c.name);
+    for (const c of ch.constraints.changed) dropConstraintStmt(t, c.name);
+    for (const c of ch.constraints.added) addConstraintStmt(t, c.name, c);
+    for (const c of ch.constraints.changed) addConstraintStmt(t, c.name, c.to);
+
+    // Indexes: a changed index is drop + re-create.
+    for (const ix of ch.indexes.dropped) dropIndexStmt(dropIndex, schema, ix.name);
+    for (const ix of ch.indexes.changed) dropIndexStmt(dropIndex, schema, ix.name);
+    for (const ix of ch.indexes.added) {
+      createIndex.push({ sql: ensureSemicolon(ix.definition), destructive: false, kind: 'create_index' });
+    }
+    for (const ix of ch.indexes.changed) {
+      createIndex.push({ sql: ensureSemicolon(ix.to.definition), destructive: false, kind: 'create_index' });
+    }
+  }
+
+  const statements = [
+    ...create, ...addColumn, ...alterColumn,
+    ...dropConstraint, ...dropIndex,
+    ...addConstraint, ...addFk, ...createIndex,
+    ...dropColumn, ...dropTable,
+  ];
+  return { statements, hasDestructive: statements.some((s) => s.destructive) };
+}
+
+function dropIndexStmt(bucket, schema, name) {
+  bucket.push({
+    sql: `DROP INDEX ${quoteQualifiedIdent(schema, name)};`,
+    destructive: true,
+    kind: 'drop_index',
+  });
+}
+
+// pg_get_indexdef has no trailing semicolon; CREATE TABLE etc. carry their own.
+function ensureSemicolon(sql) {
+  const t = sql.trimEnd();
+  return t.endsWith(';') ? t : `${t};`;
+}
+
+module.exports = {
+  introspectSchema,
+  diffSchemas,
+  buildMigration,
+};

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -27,6 +27,7 @@ const { extractExplainTiming } = require('../db/explain');
 const operations = require('../db/operations');
 const slowQueries = require('../db/slowQueries');
 const indexAdvisor = require('../db/indexAdvisor');
+const schemaDiff = require('../db/schemaDiff');
 const { txManager } = require('../db/tx');
 const views = require('../db/views');
 const savedQueries = require('../db/savedQueries');
@@ -1511,6 +1512,60 @@ router.get('/operations/indexes', requireConnection, async (req, res) => {
     res.json(advice);
   } catch (err) {
     logger.error({ err: err.message }, 'index assistant failed');
+    return sendError(res, 500, codes.DB_ERROR, err.message);
+  }
+});
+
+// ---- Schema diff & migration generator (roadmap §7.1) ----------------------
+//
+// GET /api/schema-diff?source=<connId>&target=<connId>
+//   Diffs two registered connections (each at its own configured schema) and
+//   returns the structured diff plus a forward (source→target) and backward
+//   (target→source) migration. Every generated statement is flagged destructive
+//   or not; nothing is executed — the user runs it from the editor, exactly like
+//   the index assistant's DROP DDL. This route takes two connections, so it
+//   resolves both pools itself rather than using the single-connection
+//   `requireConnection` middleware.
+
+const SchemaDiffQuery = z.object({
+  source: z.string().min(1).max(255),
+  target: z.string().min(1).max(255),
+});
+
+router.get('/schema-diff', validate({ query: SchemaDiffQuery }), async (req, res) => {
+  const { source, target } = req.query;
+  if (source === target) {
+    return sendError(res, 400, codes.BAD_REQUEST, 'Pick two different connections to diff.');
+  }
+  const sourcePool = getPool(source);
+  const targetPool = getPool(target);
+  if (!sourcePool || !targetPool) {
+    return sendError(res, 503, codes.NO_CONNECTION,
+      'One or both connections are not connected', {
+        hint: 'Reconnect both databases, then try again.',
+      });
+  }
+  const sourceSchema = getConnectionSchema(source);
+  const targetSchema = getConnectionSchema(target);
+  if (!sourceSchema || sourceSchema.includes('\0') ||
+      !targetSchema || targetSchema.includes('\0')) {
+    return sendError(res, 400, codes.BAD_REQUEST, 'A connection has an invalid schema name');
+  }
+
+  try {
+    const [sourceSnap, targetSnap] = await Promise.all([
+      schemaDiff.introspectSchema(sourcePool, sourceSchema),
+      schemaDiff.introspectSchema(targetPool, targetSchema),
+    ]);
+    res.json({
+      source: { connectionId: source, schema: sourceSchema },
+      target: { connectionId: target, schema: targetSchema },
+      diff: schemaDiff.diffSchemas(sourceSnap, targetSnap),
+      forward: schemaDiff.buildMigration(sourceSnap, targetSnap),
+      backward: schemaDiff.buildMigration(targetSnap, sourceSnap),
+    });
+  } catch (err) {
+    logger.error({ err: err.message }, 'schema diff failed');
     return sendError(res, 500, codes.DB_ERROR, err.message);
   }
 });

--- a/test/unit/schemaDiff.test.js
+++ b/test/unit/schemaDiff.test.js
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for the schema diff & migration generator (roadmap §7.1).
+ *
+ * diffSchemas/buildMigration are pure, so they're tested against hand-built
+ * snapshots — no live Postgres. The focus is the migration builder: it
+ * interpolates identifiers (the injection-relevant bit, must be quoted), flags
+ * destructive operations, and orders statements so dependencies hold. A small
+ * fakePool test covers introspectSchema's row→snapshot mapping.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  introspectSchema,
+  diffSchemas,
+  buildMigration,
+} = require('../../src/db/schemaDiff');
+
+// --- snapshot helpers -------------------------------------------------------
+
+function col(name, type, { notNull = false, def = null, ordinal = 1 } = {}) {
+  return { name, ordinal, type, notNull, default: def };
+}
+
+function snap(schema, tables) {
+  const out = { schema, tables: {} };
+  for (const [name, t] of Object.entries(tables)) {
+    out.tables[name] = {
+      columns: t.columns ?? [],
+      constraints: t.constraints ?? {},
+      indexes: t.indexes ?? {},
+    };
+  }
+  return out;
+}
+
+const sqlOf = (mig) => mig.statements.map((s) => s.sql);
+
+// --- diffSchemas ------------------------------------------------------------
+
+test('diffSchemas detects added, dropped, and changed tables', () => {
+  const from = snap('public', {
+    keep: { columns: [col('id', 'integer', { notNull: true })] },
+    gone: { columns: [col('id', 'integer')] },
+  });
+  const to = snap('public', {
+    keep: { columns: [col('id', 'integer', { notNull: true }), col('email', 'text')] },
+    fresh: { columns: [col('id', 'integer')] },
+  });
+  const diff = diffSchemas(from, to);
+  assert.deepEqual(diff.tables.added, ['fresh']);
+  assert.deepEqual(diff.tables.dropped, ['gone']);
+  assert.equal(diff.changed.length, 1);
+  assert.equal(diff.changed[0].table, 'keep');
+  assert.deepEqual(diff.changed[0].columns.added.map((c) => c.name), ['email']);
+});
+
+test('diffSchemas flags column type/nullable/default changes, ignores identical', () => {
+  const from = snap('public', {
+    t: { columns: [col('a', 'integer'), col('b', 'text', { notNull: true })] },
+  });
+  // a: type change; b: identical → no change entry.
+  const to = snap('public', {
+    t: { columns: [col('a', 'bigint'), col('b', 'text', { notNull: true })] },
+  });
+  const diff = diffSchemas(from, to);
+  assert.equal(diff.changed.length, 1);
+  assert.deepEqual(diff.changed[0].columns.changed.map((c) => c.name), ['a']);
+});
+
+test('diffSchemas returns no changed entry for identical schemas', () => {
+  const s = snap('public', { t: { columns: [col('id', 'integer')] } });
+  const diff = diffSchemas(s, structuredClone(s));
+  assert.deepEqual(diff.tables.added, []);
+  assert.deepEqual(diff.tables.dropped, []);
+  assert.deepEqual(diff.changed, []);
+});
+
+// --- buildMigration: identifier escaping ------------------------------------
+
+test('buildMigration quotes identifiers (no injection through table/column names)', () => {
+  const from = snap('public', {});
+  const to = snap('public', {
+    'ev"il': { columns: [col('c"ol', 'text')] },
+  });
+  const sql = sqlOf(buildMigration(from, to))[0];
+  assert.ok(sql.startsWith('CREATE TABLE "public"."ev""il"'), sql);
+  assert.ok(sql.includes('"c""ol" text'), sql);
+});
+
+// --- buildMigration: statement kinds & destructive flags --------------------
+
+test('buildMigration emits ADD COLUMN with NOT NULL and DEFAULT', () => {
+  const from = snap('public', { t: { columns: [col('id', 'integer')] } });
+  const to = snap('public', {
+    t: { columns: [col('id', 'integer'), col('status', 'text', { notNull: true, def: "'new'::text" })] },
+  });
+  const sql = sqlOf(buildMigration(from, to));
+  assert.ok(sql.some((s) =>
+    s === 'ALTER TABLE "public"."t" ADD COLUMN "status" text NOT NULL DEFAULT \'new\'::text;'), sql);
+});
+
+test('buildMigration flags DROP COLUMN / DROP TABLE / type change as destructive', () => {
+  const from = snap('public', {
+    t: { columns: [col('id', 'integer'), col('old', 'text')] },
+    gone: { columns: [col('id', 'integer')] },
+  });
+  const to = snap('public', {
+    t: { columns: [col('id', 'bigint')] }, // id type change + old dropped
+  });
+  const mig = buildMigration(from, to);
+  assert.equal(mig.hasDestructive, true);
+  const destructive = mig.statements.filter((s) => s.destructive).map((s) => s.kind);
+  assert.ok(destructive.includes('drop_column'));
+  assert.ok(destructive.includes('drop_table'));
+  assert.ok(destructive.includes('alter_column_type'));
+});
+
+test('buildMigration adds non-FK constraints before FK constraints', () => {
+  const from = snap('public', { orders: { columns: [col('id', 'integer')] } });
+  const to = snap('public', {
+    orders: {
+      columns: [col('id', 'integer')],
+      constraints: {
+        orders_pkey: { contype: 'p', definition: 'PRIMARY KEY (id)' },
+        orders_cust_fk: { contype: 'f', definition: 'FOREIGN KEY (cust_id) REFERENCES customers(id)' },
+      },
+    },
+  });
+  const sql = sqlOf(buildMigration(from, to));
+  const pkAt = sql.findIndex((s) => s.includes('PRIMARY KEY'));
+  const fkAt = sql.findIndex((s) => s.includes('FOREIGN KEY'));
+  assert.ok(pkAt >= 0 && fkAt >= 0 && pkAt < fkAt, sql.join('\n'));
+});
+
+test('buildMigration treats a changed index as drop + recreate', () => {
+  const from = snap('public', {
+    t: { columns: [col('a', 'text')], indexes: { t_a_idx: { definition: 'CREATE INDEX t_a_idx ON public.t USING btree (a)' } } },
+  });
+  const to = snap('public', {
+    t: { columns: [col('a', 'text')], indexes: { t_a_idx: { definition: 'CREATE UNIQUE INDEX t_a_idx ON public.t USING btree (a)' } } },
+  });
+  const stmts = buildMigration(from, to).statements;
+  const drop = stmts.find((s) => s.kind === 'drop_index');
+  const create = stmts.find((s) => s.kind === 'create_index');
+  assert.equal(drop.sql, 'DROP INDEX "public"."t_a_idx";');
+  assert.ok(create.sql.endsWith(';')); // pg_get_indexdef has no trailing ;
+  assert.ok(stmts.indexOf(drop) < stmts.indexOf(create));
+});
+
+test('buildMigration is reversible: backward = buildMigration(to, from)', () => {
+  const a = snap('public', { t: { columns: [col('id', 'integer')] } });
+  const b = snap('public', { t: { columns: [col('id', 'integer'), col('x', 'text')] } });
+  // forward adds x; the reverse drops it.
+  const fwd = sqlOf(buildMigration(a, b));
+  const back = sqlOf(buildMigration(b, a));
+  assert.ok(fwd.some((s) => s.includes('ADD COLUMN "x"')));
+  assert.ok(back.some((s) => s === 'ALTER TABLE "public"."t" DROP COLUMN "x";'));
+});
+
+// --- introspectSchema (fakePool, mirrors indexAdvisor.test.js style) --------
+
+function fakePool(matchers) {
+  return {
+    query: async (sql) => {
+      for (const [needle, rows] of matchers) {
+        if (sql.includes(needle)) return { rows, fields: [], rowCount: rows.length };
+      }
+      return { rows: [], fields: [], rowCount: 0 };
+    },
+  };
+}
+
+test('introspectSchema maps catalog rows into a normalized snapshot', async () => {
+  const pool = fakePool([
+    // 'c.relname AS table_name' (single space) is unique to TABLES_SQL; the
+    // other queries pad that column out with many spaces before AS.
+    ['c.relname AS table_name', [{ table_name: 'users' }]],
+    ['format_type', [
+      { table_name: 'users', column_name: 'id', ordinal: 1, data_type: 'integer', not_null: true, default_expr: "nextval('s')" },
+      { table_name: 'users', column_name: 'email', ordinal: 2, data_type: 'text', not_null: false, default_expr: null },
+    ]],
+    ['pg_get_constraintdef', [
+      { table_name: 'users', constraint_name: 'users_pkey', contype: 'p', definition: 'PRIMARY KEY (id)' },
+    ]],
+    ['pg_get_indexdef', [
+      { table_name: 'users', index_name: 'users_email_idx', definition: 'CREATE INDEX users_email_idx ON public.users (email)' },
+    ]],
+  ]);
+  const s = await introspectSchema(pool, 'public');
+  assert.equal(s.schema, 'public');
+  assert.equal(s.tables.users.columns.length, 2);
+  assert.deepEqual(s.tables.users.columns[0], {
+    name: 'id', ordinal: 1, type: 'integer', notNull: true, default: "nextval('s')",
+  });
+  assert.equal(s.tables.users.constraints.users_pkey.contype, 'p');
+  assert.ok(s.tables.users.indexes.users_email_idx.definition.includes('email'));
+});


### PR DESCRIPTION
## Summary

Phase 4 part 1 (v3.5.0) — **Schema diff & migration generator** (roadmap §7.1). Diff two connected databases and generate a forward/backward migration. Nothing is executed: generated SQL goes to the editor behind the Run button, same pattern as the index assistant.

- `src/db/schemaDiff.js` — `introspectSchema` (catalogs; `pg_get_constraintdef`/`pg_get_indexdef` render the DDL) + pure `diffSchemas` / `buildMigration` (reverse migration = same builder, args swapped). Statements ordered for dependency safety; each flagged `destructive` or not.
- `GET /api/schema-diff?source=&target=` — resolves both pools itself (single-conn middleware can't).
- `SchemaDiff` page + api client; wired into routeTree, tabs, Sidebar ("Diff & migrate"), TabBar.
- Unit tests: diff/migration logic + identifier escaping (no injection through names).

**Deferred** (noted in module header): `.sql` baseline-file diff (needs a DDL parser), Flyway/Alembic/Knex/Prisma formats, cross-schema-name diffs.

## Also: client API/util dedup (ponytail-audit)

- `postJson` gains `connectionId`; routes 11 hand-rolled `fetch` endpoints through it.
- new `del()` helper for DELETE endpoints.
- single `lib/download.ts` `downloadBlob` (was 4 copies) + `lib/clipboard.ts` `copyText` / `components/CopyButton` (was 3 copies).
- net **-67 lines** in client.

## Test plan

typecheck + backend (245) + client (117) unit suites + production build all green. Manual verification needed for the rewired API surface — see the branch's test checklist (runQuery/tx/updateRow/insertRow/import/backend-actions/statements, del paths, all download paths, CopyButton, and the schema-diff flow itself).