### PR TITLE
feat(jsonb): JSONB explorer (roadmap §7.3)

### DIFF
--- a/client-next/src/components/FilterBar.tsx
+++ b/client-next/src/components/FilterBar.tsx
@@ -7,6 +7,7 @@ import { Select } from '@/components/ui/select'
 import type { ColumnMeta, FilterCondition, FilterGroup, FilterOp } from '@/lib/api'
 import {
   OPERATOR_LABELS,
+  PATH_OPERATORS,
   opNeedsValue,
   opTakesArray,
   operatorsForType,
@@ -160,7 +161,11 @@ function ConditionRow({
   condition, columns, columnNames, showCombinator, combinator, onChange, onRemove,
 }: ConditionRowProps) {
   const meta = columns[condition.column]
-  const ops = useMemo(() => operatorsForType(meta?.dataType), [meta?.dataType])
+  const isPath = !!condition.path?.length
+  const ops = useMemo(
+    () => (isPath ? PATH_OPERATORS : operatorsForType(meta?.dataType)),
+    [isPath, meta?.dataType],
+  )
 
   function onColumnChange(name: string) {
     const newOps = operatorsForType(columns[name]?.dataType)
@@ -187,16 +192,26 @@ function ConditionRow({
         </span>
       )}
 
-      <Select
-        value={condition.column}
-        onChange={(e) => onColumnChange(e.target.value)}
-        className="w-40 border-0 border-r border-border"
-        aria-label="Filter column"
-      >
-        {columnNames.map((n) => (
-          <option key={n} value={n}>{n}</option>
-        ))}
-      </Select>
+      {isPath ? (
+        <span
+          className="flex items-center gap-1 border-r border-border px-2 font-mono text-xs"
+          title={`${condition.column} JSONB path`}
+        >
+          <span className="text-muted-foreground">{condition.column}</span>
+          <span className="text-foreground">{condition.path!.join('.')}</span>
+        </span>
+      ) : (
+        <Select
+          value={condition.column}
+          onChange={(e) => onColumnChange(e.target.value)}
+          className="w-40 border-0 border-r border-border"
+          aria-label="Filter column"
+        >
+          {columnNames.map((n) => (
+            <option key={n} value={n}>{n}</option>
+          ))}
+        </Select>
+      )}
 
       <Select
         value={condition.op}

--- a/client-next/src/components/JsonbExplorer.tsx
+++ b/client-next/src/components/JsonbExplorer.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Braces, ChevronDown, ChevronRight, Filter } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { CopyButton } from '@/components/CopyButton'
+import { Select } from '@/components/ui/select'
+import { Loading } from '@/components/ui/spinner'
+import { getJsonbSchema, type ColumnMeta, type JsonbPath } from '@/lib/api'
+import { jsonbAccessor } from '@/lib/filterSql'
+
+const SAMPLE_SIZE = 500
+
+/**
+ * JSONB explorer (roadmap §7.3). Samples a json/jsonb column, infers its paths,
+ * and turns each into a one-click filter or a copyable `col->'a'->>'b'`
+ * accessor. Renders nothing when the table has no json/jsonb columns, so it
+ * degrades cleanly for other column types.
+ */
+export function JsonbExplorer({
+  connectionId,
+  tableName,
+  columns,
+  onAddPathFilter,
+}: {
+  connectionId: string
+  tableName: string
+  columns: Record<string, ColumnMeta>
+  onAddPathFilter: (column: string, path: string[]) => void
+}) {
+  const jsonColumns = useMemo(
+    () =>
+      Object.entries(columns)
+        .filter(([, m]) => {
+          const t = (m.dataType ?? '').toLowerCase()
+          return t === 'jsonb' || t === 'json'
+        })
+        .map(([name]) => name),
+    [columns],
+  )
+
+  const [open, setOpen] = useState(false)
+  const [column, setColumn] = useState<string>(jsonColumns[0] ?? '')
+  const active = jsonColumns.includes(column) ? column : jsonColumns[0] ?? ''
+
+  const query = useQuery({
+    queryKey: ['jsonb', connectionId, tableName, active, SAMPLE_SIZE],
+    queryFn: ({ signal }) =>
+      getJsonbSchema(connectionId, tableName, active, SAMPLE_SIZE, signal),
+    enabled: open && !!active,
+    staleTime: 60_000,
+  })
+
+  if (jsonColumns.length === 0) return null
+
+  return (
+    <div className="border-b border-border bg-muted/30 px-4 py-2 text-sm">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+      >
+        {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+        <Braces className="h-3.5 w-3.5" />
+        JSONB explorer
+      </button>
+
+      {open && (
+        <div className="mt-2 space-y-2">
+          <div className="flex items-center gap-2">
+            <Select
+              value={active}
+              onChange={(e) => setColumn(e.target.value)}
+              className="h-8 w-48"
+              aria-label="JSONB column"
+            >
+              {jsonColumns.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </Select>
+            <span className="text-xs text-muted-foreground">
+              {query.data
+                ? `${query.data.paths.length} paths · sampled ${query.data.sampledRows} rows`
+                : `sample size ${SAMPLE_SIZE}`}
+            </span>
+          </div>
+
+          {query.isLoading && <Loading>Inferring schema…</Loading>}
+          {query.error && (
+            <p className="text-xs text-destructive">{(query.error as Error).message}</p>
+          )}
+          {query.data && query.data.paths.length === 0 && (
+            <p className="text-xs text-muted-foreground">No keys found in the sampled rows.</p>
+          )}
+
+          {query.data && query.data.paths.length > 0 && (
+            <div className="max-h-72 overflow-auto rounded-md border border-border bg-card">
+              <table className="w-full text-xs">
+                <thead className="sticky top-0 bg-card text-muted-foreground">
+                  <tr className="border-b border-border text-left">
+                    <th className="px-2 py-1.5 font-medium">Path</th>
+                    <th className="px-2 py-1.5 font-medium">Type</th>
+                    <th className="px-2 py-1.5 font-medium">Coverage</th>
+                    <th className="px-2 py-1.5 font-medium">Sample</th>
+                    <th className="px-2 py-1.5" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {query.data.paths.map((p) => (
+                    <PathRow
+                      key={p.path}
+                      column={active}
+                      path={p}
+                      onFilter={() => onAddPathFilter(active, p.accessor!)}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function PathRow({
+  column, path, onFilter,
+}: {
+  column: string
+  path: JsonbPath
+  onFilter: () => void
+}) {
+  const filterable = path.accessor != null
+  return (
+    <tr className="border-b border-border/60 last:border-0">
+      <td className="px-2 py-1 font-mono text-foreground">{path.path}</td>
+      <td className="px-2 py-1 text-muted-foreground">{path.types.join(' | ')}</td>
+      <td className="px-2 py-1 text-muted-foreground">
+        {Math.round(path.frequency * 100)}%
+      </td>
+      <td className="max-w-[16rem] truncate px-2 py-1 font-mono text-muted-foreground">
+        {path.sample == null ? '—' : String(path.sample)}
+      </td>
+      <td className="px-2 py-1">
+        {filterable ? (
+          <div className="flex items-center justify-end gap-1">
+            <Button size="sm" variant="ghost" className="h-7" onClick={onFilter}>
+              <Filter className="h-3.5 w-3.5" /> Filter
+            </Button>
+            <CopyButton text={jsonbAccessor(column, path.accessor!)} label="Copy" />
+          </div>
+        ) : (
+          <span className="block text-right text-[10px] text-muted-foreground/70">in array</span>
+        )}
+      </td>
+    </tr>
+  )
+}

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -506,12 +506,15 @@ export type FilterOp =
   | 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte'
   | 'like' | 'ilike' | 'in' | 'nin'
   | 'is_null' | 'is_not_null'
-  | 'jsonb_contains' | 'array_overlaps'
+  | 'jsonb_contains' | 'has_key' | 'array_overlaps'
 
 export interface FilterCondition {
   type: 'condition'
   column: string
   op: FilterOp
+  // JSONB key path (object keys) for path conditions from the explorer; the
+  // server compares the text at `column #>> path`.
+  path?: string[]
   value?: unknown
 }
 
@@ -567,6 +570,7 @@ const FilterConditionApi = z.object({
   type: z.literal('condition'),
   column: z.string(),
   op: z.string(),
+  path: z.array(z.string()).optional(),
   value: z.unknown().optional(),
 })
 type FilterGroupApi = {
@@ -916,6 +920,43 @@ export function getAggregates(
   return api(
     `/api/tables/${encodeURIComponent(tableName)}/aggregate?${qs.toString()}`,
     AggregateResponse,
+    { connectionId, signal },
+  )
+}
+
+// ---- JSONB schema inference (roadmap §7.3) ----------------------------------
+
+const JsonbPathSchema = z.object({
+  path: z.string(),
+  // Object-key chain for the `#>>` accessor; null when the path crosses an
+  // array and so isn't directly filterable.
+  accessor: z.array(z.string()).nullable(),
+  types: z.array(z.string()),
+  occurrences: z.number(),
+  frequency: z.number(),
+  sample: z.unknown(),
+})
+export type JsonbPath = z.infer<typeof JsonbPathSchema>
+
+const JsonbSchemaResponse = z.object({
+  column: z.string(),
+  sampleSize: z.number(),
+  sampledRows: z.number(),
+  paths: z.array(JsonbPathSchema),
+})
+export type JsonbSchema = z.infer<typeof JsonbSchemaResponse>
+
+export function getJsonbSchema(
+  connectionId: string,
+  tableName: string,
+  column: string,
+  sample = 500,
+  signal?: AbortSignal,
+) {
+  const qs = new URLSearchParams({ column, sample: String(sample) })
+  return api(
+    `/api/tables/${encodeURIComponent(tableName)}/jsonb?${qs.toString()}`,
+    JsonbSchemaResponse,
     { connectionId, signal },
   )
 }

--- a/client-next/src/lib/filterSql.ts
+++ b/client-next/src/lib/filterSql.ts
@@ -22,7 +22,9 @@ function renderNode(node: FilterCondition | FilterGroup): string {
 }
 
 function renderCondition(c: FilterCondition): string {
-  const col = quoteIdent(c.column)
+  // Path conditions read the text at `col->'a'->>'b'`; everything else operates
+  // on the bare column. (Display form — the server uses `#>>` with bound params.)
+  const col = c.path && c.path.length ? jsonbAccessor(c.column, c.path) : quoteIdent(c.column)
   switch (c.op) {
     case 'is_null': return `${col} IS NULL`
     case 'is_not_null': return `${col} IS NOT NULL`
@@ -37,12 +39,24 @@ function renderCondition(c: FilterCondition): string {
     case 'in':  return `${col} IN (${arrayLiteral(c.value)})`
     case 'nin': return `${col} NOT IN (${arrayLiteral(c.value)})`
     case 'jsonb_contains': return `${col} @> ${jsonbLiteral(c.value)}`
+    case 'has_key': return `jsonb_exists(${quoteIdent(c.column)}, ${literal(c.value)})`
     case 'array_overlaps': return `${col} && ARRAY[${arrayLiteral(c.value)}]`
   }
 }
 
 function quoteIdent(name: string): string {
   return `"${name.replaceAll('"', '""')}"`
+}
+
+/** `"col"->'a'->>'b'` for a JSONB key path — matches the roadmap's accessor form. */
+export function jsonbAccessor(column: string, path: string[]): string {
+  const col = quoteIdent(column)
+  if (path.length === 0) return col
+  const hops = path.map((k, i) => {
+    const key = `'${k.replaceAll("'", "''")}'`
+    return i === path.length - 1 ? `->>${key}` : `->${key}`
+  })
+  return col + hops.join('')
 }
 
 function literal(v: unknown): string {
@@ -75,6 +89,7 @@ export const OPERATOR_LABELS: Record<FilterOp, string> = {
   is_null: 'IS NULL',
   is_not_null: 'IS NOT NULL',
   jsonb_contains: '@>',
+  has_key: 'has key',
   array_overlaps: '&&',
 }
 
@@ -94,10 +109,15 @@ export function operatorsForType(dataType: string | undefined): FilterOp[] {
   if (isBool) return ['eq', 'neq', 'is_null', 'is_not_null']
   if (isNumeric || isDateish) return ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'nin', 'is_null', 'is_not_null']
   if (isText) return ['eq', 'neq', 'like', 'ilike', 'in', 'nin', 'is_null', 'is_not_null']
-  if (isJson) return ['jsonb_contains', 'is_null', 'is_not_null']
+  if (isJson) return ['jsonb_contains', 'has_key', 'is_null', 'is_not_null']
   if (isArray) return ['array_overlaps', 'is_null', 'is_not_null']
   return [...base, 'gt', 'gte', 'lt', 'lte', 'in', 'nin']
 }
+
+/** Operators a JSONB path condition (text extracted via `#>>`) may use. */
+export const PATH_OPERATORS: FilterOp[] = [
+  'eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'like', 'ilike', 'is_null', 'is_not_null',
+]
 
 export function opNeedsValue(op: FilterOp): boolean {
   return op !== 'is_null' && op !== 'is_not_null'

--- a/client-next/src/pages/TableView.tsx
+++ b/client-next/src/pages/TableView.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
 import { DataGrid, type SortState } from "@/components/DataGrid";
 import { EMPTY_FILTER, FilterBar } from "@/components/FilterBar";
+import { JsonbExplorer } from "@/components/JsonbExplorer";
 import { SortBar } from "@/components/SortBar";
 import { ViewBar } from "@/components/ViewBar";
 import { InsertRowDialog } from "@/components/InsertRowDialog";
@@ -436,6 +437,23 @@ export function TableView() {
               setSort(next);
             }}
           />
+          {connectionId && (
+            <JsonbExplorer
+              connectionId={connectionId}
+              tableName={tableName}
+              columns={data.columns}
+              onAddPathFilter={(column, path) => {
+                setPage(1);
+                setFilter((prev) => ({
+                  ...prev,
+                  children: [
+                    ...prev.children,
+                    { type: "condition", column, op: "eq", path, value: "" },
+                  ],
+                }));
+              }}
+            />
+          )}
         </>
       )}
 

--- a/src/db/filter.js
+++ b/src/db/filter.js
@@ -16,7 +16,14 @@
  *   in, nin                     = ANY($) | <> ALL($)        value: non-empty array
  *   is_null, is_not_null         IS NULL | IS NOT NULL      (no value)
  *   jsonb_contains              @> $::jsonb                 (jsonb columns only)
+ *   has_key                     jsonb_exists(col, $)        (jsonb columns only)
  *   array_overlaps              && $                        (array columns only)
+ *
+ * JSONB path conditions (roadmap §7.3 path builder): a condition on a json/jsonb
+ * column may carry a `path` (array of object keys). The left-hand side then
+ * becomes `(col #>> $path::text[])` — the text at that path — which the standard
+ * comparison and null operators apply to. ponytail: path comparisons are text
+ * only; numeric/date casting on a path is deferred until someone needs it.
  */
 
 const { z } = require('zod');
@@ -26,10 +33,19 @@ const OPS = new Set([
   'eq', 'neq', 'gt', 'gte', 'lt', 'lte',
   'like', 'ilike', 'in', 'nin',
   'is_null', 'is_not_null',
-  'jsonb_contains', 'array_overlaps',
+  'jsonb_contains', 'has_key', 'array_overlaps',
 ]);
 const VALUELESS_OPS = new Set(['is_null', 'is_not_null']);
 const ARRAY_OPS = new Set(['in', 'nin', 'array_overlaps']);
+// Operators usable on the text extracted by a JSONB `path`, and the SQL each
+// renders to (valueless ops handled separately).
+const PATH_OPS = new Set([
+  'eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'like', 'ilike', 'is_null', 'is_not_null',
+]);
+const PATH_SQL = {
+  eq: '=', neq: '<>', gt: '>', gte: '>=', lt: '<', lte: '<=',
+  like: 'LIKE', ilike: 'ILIKE',
+};
 
 const MAX_DEPTH = 5;
 const MAX_CONDITIONS = 50;
@@ -38,8 +54,17 @@ const ConditionSchema = z.object({
   type: z.literal('condition'),
   column: z.string().min(1).max(255).refine(s => !s.includes('\0'), 'null byte'),
   op: z.string().refine(o => OPS.has(o), 'unknown operator'),
+  // JSONB key path for the path builder. Object keys only; array traversal is
+  // not expressible as a #>> path, so the explorer never emits one.
+  path: z.array(z.string().min(1).max(255).refine(s => !s.includes('\0'), 'null byte'))
+    .min(1).max(20).optional(),
   value: z.unknown().optional(),
 });
+
+function isJsonColumn(meta) {
+  const t = (meta.dataType || '').toLowerCase();
+  return t === 'jsonb' || t === 'json';
+}
 
 const GroupSchema = z.lazy(() => z.object({
   type: z.literal('group'),
@@ -97,6 +122,39 @@ function buildCondition(node, columns, state) {
 
   const col = quoteIdent(node.column);
   const op = node.op;
+
+  // JSONB path condition: compare the text at `col #>> {path}`. The path is
+  // bound as a single text[] parameter, so nothing from the path reaches SQL
+  // as an identifier — no injection surface.
+  if (node.path) {
+    if (!isJsonColumn(meta)) {
+      throw new Error(`Path conditions are only valid on json/jsonb columns`);
+    }
+    if (!PATH_OPS.has(op)) {
+      throw new Error(`Operator ${op} cannot be used with a JSONB path`);
+    }
+    state.params.push(node.path);
+    const lhs = `(${col} #>> $${state.params.length}::text[])`;
+    if (VALUELESS_OPS.has(op)) {
+      return `${lhs} ${op === 'is_null' ? 'IS NULL' : 'IS NOT NULL'}`;
+    }
+    if (op === 'like' || op === 'ilike') {
+      if (typeof node.value !== 'string') throw new Error(`${op} requires a string value`);
+    }
+    state.params.push(node.value == null ? null : String(node.value));
+    return `${lhs} ${PATH_SQL[op]} $${state.params.length}`;
+  }
+
+  if (op === 'has_key') {
+    if (!isJsonColumn(meta)) {
+      throw new Error(`has_key is only valid on json/jsonb columns`);
+    }
+    if (typeof node.value !== 'string') {
+      throw new Error(`has_key requires a string key`);
+    }
+    state.params.push(node.value);
+    return `jsonb_exists(${col}, $${state.params.length})`;
+  }
 
   if (VALUELESS_OPS.has(op)) {
     return `${col} ${op === 'is_null' ? 'IS NULL' : 'IS NOT NULL'}`;

--- a/src/db/jsonbSchema.js
+++ b/src/db/jsonbSchema.js
@@ -1,0 +1,123 @@
+/**
+ * JSONB schema inference (roadmap §7.3).
+ *
+ * Sample N rows of a json/jsonb column and walk the parsed values in JS to infer
+ * the set of paths, the types seen at each, how often each occurs, and one
+ * sample value. The driver already parses jsonb into JS objects, so walking in
+ * JS handles arbitrary nesting for free — far simpler (and more correct) than a
+ * recursive catalog query.
+ *
+ * Object keys produce a filterable `path` (the `col #>> {path}` accessor the
+ * path builder emits). Anything reached by descending into an array is shown
+ * for orientation but not filterable, since array traversal isn't expressible
+ * as a #>> path.
+ *
+ * ponytail: head sample (`LIMIT n`) — biased toward the table's physical start.
+ * Swap in `TABLESAMPLE` if that bias ever bites on a real table.
+ */
+
+const { quoteIdent } = require('./identifier');
+
+const MAX_PATHS = 300;          // cap output for pathological wide documents
+const MAX_SAMPLE_LEN = 200;     // truncate long sample strings
+
+function jsType(v) {
+  if (v === null) return 'null';
+  return typeof v; // 'string' | 'number' | 'boolean'
+}
+
+function record(paths, seen, display, accessor, type, sample) {
+  let e = paths.get(display);
+  if (!e) {
+    if (paths.size >= MAX_PATHS) return;
+    e = { display, accessor, types: new Set(), occ: 0, sample: undefined };
+    paths.set(display, e);
+  }
+  e.types.add(type);
+  if (e.sample === undefined && sample !== undefined && type !== 'null') {
+    e.sample = typeof sample === 'string' && sample.length > MAX_SAMPLE_LEN
+      ? sample.slice(0, MAX_SAMPLE_LEN) + '…'
+      : sample;
+  }
+  if (!seen.has(display)) {
+    e.occ += 1;
+    seen.add(display);
+  }
+}
+
+/**
+ * Walk one JSON value.
+ * @param accessor  object-key chain to here (null once an array was crossed —
+ *                  the path is no longer a valid #>> accessor)
+ * @param display   human path string, with `[]` marking array descents
+ */
+function visit(node, accessor, display, paths, seen) {
+  if (Array.isArray(node)) {
+    if (display) record(paths, seen, display, accessor, 'array', undefined);
+    const childDisplay = display ? `${display}[]` : '[]';
+    for (const el of node) visit(el, null, childDisplay, paths, seen);
+  } else if (node !== null && typeof node === 'object') {
+    for (const [k, v] of Object.entries(node)) {
+      const seg = display ? `${display}.${k}` : k;
+      visit(v, accessor ? [...accessor, k] : null, seg, paths, seen);
+    }
+  } else if (display) {
+    record(paths, seen, display, accessor, jsType(node), node);
+  }
+}
+
+/** Pure: infer the path map from already-fetched sample values. */
+function inferFromValues(values) {
+  const paths = new Map();
+  for (const v of values) {
+    visit(v, [], '', paths, new Set());
+  }
+  const total = values.length || 1;
+  return [...paths.values()]
+    .map((e) => ({
+      path: e.display,
+      accessor: e.accessor,            // string[] | null — null = not filterable
+      types: [...e.types].sort(),
+      occurrences: e.occ,
+      frequency: e.occ / total,
+      sample: e.sample ?? null,
+    }))
+    .sort((a, b) => b.occurrences - a.occurrences || a.path.localeCompare(b.path));
+}
+
+/**
+ * Sample a json/jsonb column and infer its shape.
+ * @returns {Promise<{ column, sampleSize, sampledRows, paths }>}
+ */
+async function inferJsonbSchema(pool, qualifiedTable, column, columnMetadata, sampleSize) {
+  const meta = columnMetadata[column];
+  if (!meta) {
+    const err = new Error(`Unknown column: ${column}`);
+    err.statusCode = 400;
+    throw err;
+  }
+  const t = (meta.dataType || '').toLowerCase();
+  if (t !== 'jsonb' && t !== 'json') {
+    const err = new Error(`Column "${column}" is ${meta.dataType}, not json/jsonb`);
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const col = quoteIdent(column);
+  const sql = `SELECT ${col} AS v FROM ${qualifiedTable} WHERE ${col} IS NOT NULL LIMIT $1`;
+  const result = await pool.query(sql, [sampleSize]);
+  // json columns may arrive as strings; jsonb arrives parsed.
+  const values = result.rows.map((r) => {
+    if (typeof r.v !== 'string') return r.v;
+    try { return JSON.parse(r.v); } catch { return null; }
+  });
+
+  return {
+    column,
+    sampleSize,
+    sampledRows: values.length,
+    paths: inferFromValues(values),
+  };
+}
+
+module.exports = { inferJsonbSchema, inferFromValues, MAX_PATHS };

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -18,6 +18,7 @@ const { quoteIdent, quoteQualifiedIdent } = require('../db/identifier');
 const { buildWhere } = require('../db/filter');
 const { buildOrderBy } = require('../db/sort');
 const { computeAggregates } = require('../db/aggregate');
+const { inferJsonbSchema } = require('../db/jsonbSchema');
 const { buildUpdateRow } = require('../db/update');
 const { buildInsertRow } = require('../db/insert');
 const { EXPORT_FORMATS, FORMAT_META, createSerializer, sqlLiteral } = require('../db/export');
@@ -512,6 +513,45 @@ router.get('/tables/:tableName/aggregate',
       res.json(result);
     } catch (err) {
       logger.error({ err: err.message, table: tableName }, 'aggregate failed');
+      return sendError(res, 500, codes.DB_ERROR, err.message);
+    }
+  });
+
+// ---- JSONB schema inference (roadmap §7.3) ----------------------------------
+//
+// GET /api/tables/:tableName/jsonb?column=<col>&sample=<n>
+//   Samples up to `sample` non-null rows of a json/jsonb column and returns the
+//   inferred paths, their types, occurrence frequency, and a sample value. The
+//   JSONB explorer turns these into "add filter" / "copy accessor" actions.
+
+const JsonbQuery = z.object({
+  column: z.string().min(1).max(255).refine((s) => !s.includes('\0'), 'null byte'),
+  sample: z.coerce.number().int().min(1).max(5000).default(500),
+});
+
+router.get('/tables/:tableName/jsonb',
+  requireConnection,
+  validate({
+    params: z.object({ tableName: TableNameSchema }),
+    query: JsonbQuery,
+  }),
+  async (req, res) => {
+    const tableName = req.params.tableName;
+    const pool = req.pool;
+    const schema = req.schema;
+    const qualifiedTable = quoteQualifiedIdent(schema, tableName);
+    try {
+      const { columns: columnMetadata } =
+        await getTableMetadata(pool, req.connectionId, schema, tableName);
+      const result = await inferJsonbSchema(
+        pool, qualifiedTable, req.query.column, columnMetadata, req.query.sample,
+      );
+      res.json(result);
+    } catch (err) {
+      if (err.statusCode === 400) {
+        return sendError(res, 400, codes.BAD_REQUEST, err.message);
+      }
+      logger.error({ err: err.message, table: tableName }, 'jsonb inference failed');
       return sendError(res, 500, codes.DB_ERROR, err.message);
     }
   });

--- a/test/unit/filter.test.js
+++ b/test/unit/filter.test.js
@@ -115,6 +115,62 @@ test('jsonb_contains rejects non-jsonb columns', () => {
   }, cols), /json\/jsonb/);
 });
 
+test('has_key emits jsonb_exists with the key as a string param', () => {
+  const { sql, params } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'payload', op: 'has_key', value: 'sku' }],
+  }, cols);
+  assert.equal(sql, ' WHERE jsonb_exists("payload", $1)');
+  assert.deepEqual(params, ['sku']);
+});
+
+test('has_key rejects non-jsonb columns', () => {
+  assert.throws(() => buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'name', op: 'has_key', value: 'x' }],
+  }, cols), /json\/jsonb/);
+});
+
+test('jsonb path eq binds the path as text[] and compares extracted text', () => {
+  const { sql, params } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'payload', op: 'eq', path: ['a', 'b'], value: 'x' }],
+  }, cols);
+  assert.equal(sql, ' WHERE ("payload" #>> $1::text[]) = $2');
+  assert.deepEqual(params, [['a', 'b'], 'x']);
+});
+
+test('jsonb path coerces non-string compare values to text', () => {
+  const { params } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'payload', op: 'gt', path: ['n'], value: 5 }],
+  }, cols);
+  assert.deepEqual(params, [['n'], '5']);
+});
+
+test('jsonb path is_null needs no value', () => {
+  const { sql, params } = buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'payload', op: 'is_null', path: ['a'] }],
+  }, cols);
+  assert.equal(sql, ' WHERE ("payload" #>> $1::text[]) IS NULL');
+  assert.deepEqual(params, [['a']]);
+});
+
+test('jsonb path rejects non-json columns', () => {
+  assert.throws(() => buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'name', op: 'eq', path: ['a'], value: 'x' }],
+  }, cols), /json\/jsonb/);
+});
+
+test('jsonb path rejects operators it cannot express', () => {
+  assert.throws(() => buildWhere({
+    type: 'group', combinator: 'and',
+    children: [{ type: 'condition', column: 'payload', op: 'jsonb_contains', path: ['a'], value: {} }],
+  }, cols), /cannot be used with a JSONB path/);
+});
+
 test('array_overlaps emits && with array param', () => {
   const { sql, params } = buildWhere({
     type: 'group', combinator: 'and',

--- a/test/unit/jsonbSchema.test.js
+++ b/test/unit/jsonbSchema.test.js
@@ -1,0 +1,42 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { inferFromValues } = require('../../src/db/jsonbSchema');
+
+function byPath(paths) {
+  return Object.fromEntries(paths.map((p) => [p.path, p]));
+}
+
+test('infers top-level keys with types and coverage', () => {
+  const paths = byPath(inferFromValues([
+    { id: 1, name: 'a' },
+    { id: 2, name: 'b', active: true },
+  ]));
+  assert.deepEqual(paths.id.accessor, ['id']);
+  assert.deepEqual(paths.id.types, ['number']);
+  assert.equal(paths.id.frequency, 1);          // in both rows
+  assert.equal(paths.active.occurrences, 1);    // only the second row
+  assert.equal(paths.active.frequency, 0.5);
+});
+
+test('nested object keys produce a dotted path and a key-chain accessor', () => {
+  const [p] = inferFromValues([{ addr: { city: 'NYC' } }]).filter((x) => x.path === 'addr.city');
+  assert.deepEqual(p.accessor, ['addr', 'city']);
+  assert.equal(p.sample, 'NYC');
+});
+
+test('mixed types at one path are merged and sorted', () => {
+  const paths = byPath(inferFromValues([{ v: 1 }, { v: 'x' }, { v: null }]));
+  assert.deepEqual(paths.v.types, ['null', 'number', 'string']);
+});
+
+test('array descent is marked unfilterable (null accessor) and gets [] display', () => {
+  const paths = byPath(inferFromValues([{ tags: [{ name: 'x' }] }]));
+  assert.equal(paths.tags.types[0], 'array');
+  assert.deepEqual(paths.tags.accessor, ['tags']);  // the array itself is reachable
+  assert.equal(paths['tags[].name'].accessor, null); // inside the array is not
+});
+
+test('empty sample yields no paths and no divide-by-zero', () => {
+  assert.deepEqual(inferFromValues([]), []);
+});


### PR DESCRIPTION
## What

JSONB explorer (roadmap §7.3). Sample a json/jsonb column, infer its key paths, types, coverage, and a sample value, then turn each into a one-click filter or a copyable `col->'a'->>'b'` accessor.

## Changes

**Backend**
- `src/db/jsonbSchema.js` — sample N non-null rows, walk parsed JSON in JS to infer paths. Object keys get a `#>>` accessor; array-descended keys are flagged unfilterable.
- `GET /api/tables/:table/jsonb?column&sample`
- `src/db/filter.js` — JSONB path conditions (`(col #>> $path::text[]) <op> $val`, path bound as one `text[]` param — no injection surface) + `has_key` → `jsonb_exists`. `@>` already existed.

**Frontend**
- `JsonbExplorer.tsx` — collapsible panel in TableView; per-path **Filter** + **Copy accessor**. Renders nothing when no json/jsonb columns (degrades for other engines).
- FilterBar / filterSql / api wired for path conditions + `has_key`; saved views round-trip the new `path` field.
- JSON tree cell popup (`JsonViewer.tsx`) already existed — left as-is.

## Tests

- 267 backend unit tests pass; 12 new (`filter` path/has_key + `jsonbSchema` inference).
- `tsc -b` clean. Lint skipped (pre-existing config breakage).

## Deferred (ponytail)

- Add-path-to-SELECT projection (touches grid/virtualization).
- Nested key-exists, numeric/date path casts (text compare only).
- Head sample (`LIMIT n`) — swap to `TABLESAMPLE` if head-bias bites.