### PR TITLE
feat(extensions): add extensions panel

### DIFF
--- a/client-next/src/components/Sidebar.tsx
+++ b/client-next/src/components/Sidebar.tsx
@@ -5,8 +5,8 @@ import {
 } from '@tanstack/react-router'
 import {
   Activity, Bookmark, ChevronDown, ChevronRight, Download, Eye, GitBranch,
-  GitCompare, Lightbulb, MoreVertical, Network, Pencil, Plus, Power, Search,
-  Table as TableIcon, Terminal, Timer,
+  GitCompare, Lightbulb, MoreVertical, Network, Pencil, Plus, Power, Puzzle,
+  Search, Table as TableIcon, Terminal, Timer,
 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -359,6 +359,17 @@ export function Sidebar() {
           >
             <Lightbulb className="h-3.5 w-3.5 text-muted-foreground" />
             Index assistant
+          </Link>
+          <Link
+            to="/extensions"
+            onClick={() => openTab({ kind: 'extensions' })}
+            className={cn(
+              'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
+              !!matchRoute({ to: '/extensions' }) && 'bg-accent text-accent-foreground',
+            )}
+          >
+            <Puzzle className="h-3.5 w-3.5 text-muted-foreground" />
+            Extensions
           </Link>
         </Section>
       )}

--- a/client-next/src/components/TabBar.tsx
+++ b/client-next/src/components/TabBar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
-import { X, Home, Table as TableIcon, Terminal, GitBranch, GitCompare, Activity, Timer, Lightbulb, Network } from 'lucide-react'
+import { X, Home, Table as TableIcon, Terminal, GitBranch, GitCompare, Activity, Timer, Lightbulb, Network, Puzzle } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Dialog } from '@/components/ui/dialog'
@@ -23,6 +23,7 @@ function routeToTab(pathname: string): Tab {
   if (pathname === '/slow-queries') return { kind: 'slow-queries' }
   if (pathname === '/index-assistant') return { kind: 'index-assistant' }
   if (pathname === '/schema-diff') return { kind: 'schema-diff' }
+  if (pathname === '/extensions') return { kind: 'extensions' }
   return { kind: 'home' }
 }
 
@@ -36,6 +37,7 @@ function tabIcon(t: Tab) {
     case 'slow-queries': return Timer
     case 'index-assistant': return Lightbulb
     case 'schema-diff': return GitCompare
+    case 'extensions': return Puzzle
     case 'home': return Home
   }
 }

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -1223,6 +1223,46 @@ export function getIndexAdvice(connectionId: string, signal?: AbortSignal) {
   return api('/api/operations/indexes', IndexAdviceSchema, { connectionId, signal })
 }
 
+// ---- Extensions panel (roadmap §7.4) ----------------------------------------
+
+const ExtensionSchema = z.object({
+  name: z.string(),
+  installedVersion: z.string().nullable(),
+  defaultVersion: z.string().nullable(),
+  comment: z.string().nullable(),
+  installed: z.boolean(),
+  popular: z.boolean(),
+})
+export type Extension = z.infer<typeof ExtensionSchema>
+
+// `superuser` is advisory — trusted extensions install for non-superusers too.
+const ExtensionsResponse = z.object({
+  superuser: z.boolean(),
+  extensions: z.array(ExtensionSchema),
+})
+export type ExtensionsResult = z.infer<typeof ExtensionsResponse>
+
+export function listExtensions(connectionId: string, signal?: AbortSignal) {
+  return api('/api/operations/extensions', ExtensionsResponse, { connectionId, signal })
+}
+
+const InstallExtensionResponse = z.object({
+  installed: z.boolean(),
+  installedVersion: z.string().nullable(),
+})
+
+/** CREATE EXTENSION IF NOT EXISTS (idempotent; usually needs a privileged role). */
+export function installExtension(connectionId: string, name: string) {
+  return postJson('/api/operations/extensions/install', { name },
+    InstallExtensionResponse, 'POST', connectionId)
+}
+
+/** DROP EXTENSION IF EXISTS (RESTRICT — fails if other objects depend on it). */
+export function dropExtension(connectionId: string, name: string) {
+  return postJson('/api/operations/extensions/drop', { name },
+    InstallExtensionResponse, 'POST', connectionId)
+}
+
 // ---- Schema diff & migration generator (roadmap §7.1) -----------------------
 
 // One generated migration statement. `destructive` (DROP / column-type change)

--- a/client-next/src/pages/Extensions.tsx
+++ b/client-next/src/pages/Extensions.tsx
@@ -1,0 +1,249 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { AlertTriangle, Download, Puzzle, RefreshCw, Search, Star, Trash2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { CopyButton } from '@/components/CopyButton'
+import { Dialog } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Loading, Spinner } from '@/components/ui/spinner'
+import { dropExtension, installExtension, listExtensions, type Extension } from '@/lib/api'
+import { useConnectionStore } from '@/store/connection'
+
+const installDdl = (name: string) => `CREATE EXTENSION IF NOT EXISTS "${name}";`
+const dropDdl = (name: string) => `DROP EXTENSION IF EXISTS "${name}";`
+
+export function Extensions() {
+  const connectionId = useConnectionStore((s) => s.activeConnectionId)
+  const qc = useQueryClient()
+  const [search, setSearch] = useState('')
+
+  const exts = useQuery({
+    queryKey: ['extensions', connectionId],
+    queryFn: ({ signal }) => listExtensions(connectionId!, signal),
+    enabled: !!connectionId,
+    placeholderData: (prev) => prev,
+  })
+
+  const install = useMutation({
+    mutationFn: (name: string) => installExtension(connectionId!, name),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['extensions', connectionId] }),
+  })
+
+  // Drop is destructive, so it goes through a confirm dialog (`pendingDrop`).
+  const [pendingDrop, setPendingDrop] = useState<string | null>(null)
+  const drop = useMutation({
+    mutationFn: (name: string) => dropExtension(connectionId!, name),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['extensions', connectionId] })
+      setPendingDrop(null)
+    },
+  })
+
+  // Popular first, then alphabetical (server already sorts by name).
+  const filtered = useMemo(() => {
+    const all = exts.data?.extensions ?? []
+    const q = search.trim().toLowerCase()
+    const matched = q
+      ? all.filter((e) =>
+          e.name.toLowerCase().includes(q) ||
+          (e.comment?.toLowerCase().includes(q) ?? false))
+      : all
+    return [...matched].sort((a, b) => Number(b.popular) - Number(a.popular))
+  }, [exts.data, search])
+
+  if (!connectionId) {
+    return (
+      <div className="px-10 py-10 text-sm text-muted-foreground">No active connection.</div>
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="flex items-center justify-between border-b border-border px-6 py-3">
+        <div>
+          <h1 className="text-lg font-semibold">Extensions</h1>
+          <p className="text-xs text-muted-foreground">
+            Available Postgres extensions · one-click <code className="font-mono">CREATE EXTENSION</code>
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => exts.refetch()}
+          disabled={exts.isFetching}
+          title="Refresh"
+        >
+          {exts.isFetching ? <Spinner aria-label="Refreshing" /> : <RefreshCw className="h-3.5 w-3.5" />}
+          Refresh
+        </Button>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-auto px-6 py-4">
+        {exts.isLoading && (
+          <div className="py-10 text-center text-sm text-muted-foreground">
+            <Loading>Loading extensions…</Loading>
+          </div>
+        )}
+
+        {exts.error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {(exts.error as Error).message}
+          </div>
+        )}
+
+        {exts.data && (
+          <div className="space-y-3">
+            {!exts.data.superuser && (
+              <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-2.5 text-xs text-amber-700 dark:text-amber-400">
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <span>
+                  You are not connected as a superuser. Installing most extensions will fail —
+                  only trusted extensions (PG13+) can be created by non-superusers.
+                </span>
+              </div>
+            )}
+
+            {install.error && (
+              <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-2.5 text-xs text-destructive">
+                {(install.error as Error).message}
+              </div>
+            )}
+
+            <div className="relative max-w-sm">
+              <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Filter extensions…"
+                className="h-8 pl-7 text-sm"
+              />
+            </div>
+
+            <ul className="divide-y divide-border/50 overflow-hidden rounded-lg border border-border bg-card">
+              {filtered.length === 0 ? (
+                <li className="px-4 py-6 text-center text-xs text-muted-foreground">
+                  No extensions match.
+                </li>
+              ) : (
+                filtered.map((e) => (
+                  <Row
+                    key={e.name}
+                    ext={e}
+                    installing={install.isPending && install.variables === e.name}
+                    onInstall={() => install.mutate(e.name)}
+                    onUninstall={() => setPendingDrop(e.name)}
+                  />
+                ))
+              )}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      <Dialog
+        open={pendingDrop !== null}
+        onClose={() => {
+          if (drop.isPending) return
+          setPendingDrop(null)
+          drop.reset()
+        }}
+        title="Uninstall extension?"
+        footer={
+          <>
+            <Button variant="outline" size="sm" onClick={() => setPendingDrop(null)} disabled={drop.isPending}>
+              Keep
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => pendingDrop && drop.mutate(pendingDrop)}
+              disabled={drop.isPending}
+            >
+              {drop.isPending && <Spinner aria-label="Uninstalling" />}
+              Uninstall
+            </Button>
+          </>
+        }
+      >
+        <p className="text-sm text-muted-foreground">
+          This runs{' '}
+          <code className="font-mono text-foreground">{pendingDrop && dropDdl(pendingDrop)}</code>.
+          It fails if other objects depend on the extension (RESTRICT) — nothing is force-dropped.
+        </p>
+        {drop.error && <p className="mt-3 text-xs text-destructive">{(drop.error as Error).message}</p>}
+      </Dialog>
+    </div>
+  )
+}
+
+function Row({
+  ext, installing, onInstall, onUninstall,
+}: {
+  ext: Extension
+  installing: boolean
+  onInstall: () => void
+  onUninstall: () => void
+}) {
+  return (
+    <li className="flex items-start justify-between gap-3 px-4 py-2.5">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 text-sm">
+          <Puzzle className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <code className="font-mono font-medium">{ext.name}</code>
+          {ext.popular && (
+            <Star className="h-3 w-3 shrink-0 fill-amber-400 text-amber-400" aria-label="Popular" />
+          )}
+          {ext.installed ? (
+            <span className="rounded bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+              installed v{ext.installedVersion}
+              {ext.defaultVersion && ext.defaultVersion !== ext.installedVersion &&
+                ` · v${ext.defaultVersion} available`}
+            </span>
+          ) : (
+            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              v{ext.defaultVersion}
+            </span>
+          )}
+        </div>
+        {ext.comment && (
+          <p className="mt-0.5 truncate text-[11px] text-muted-foreground" title={ext.comment}>
+            {ext.comment}
+          </p>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        {ext.installed ? (
+          <>
+            <CopyButton text={dropDdl(ext.name)} label="Copy SQL" />
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-destructive hover:text-destructive"
+              onClick={onUninstall}
+              title={dropDdl(ext.name)}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Uninstall
+            </Button>
+          </>
+        ) : (
+          <>
+            <CopyButton text={installDdl(ext.name)} label="Copy SQL" />
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7"
+              onClick={onInstall}
+              disabled={installing}
+              title={installDdl(ext.name)}
+            >
+              {installing ? <Spinner aria-label="Installing" /> : <Download className="h-3.5 w-3.5" />}
+              Install
+            </Button>
+          </>
+        )}
+      </div>
+    </li>
+  )
+}

--- a/client-next/src/routeTree.tsx
+++ b/client-next/src/routeTree.tsx
@@ -8,6 +8,7 @@ import { Operations } from './pages/Operations'
 import { SlowQueries } from './pages/SlowQueries'
 import { IndexAssistant } from './pages/IndexAssistant'
 import { SchemaDiff } from './pages/SchemaDiff'
+import { Extensions } from './pages/Extensions'
 import { Sidebar } from './components/Sidebar'
 import { TabBar } from './components/TabBar'
 import { Spotlight } from './components/Spotlight'
@@ -104,6 +105,12 @@ const schemaDiffRoute = createRoute({
   component: SchemaDiff,
 })
 
+const extensionsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/extensions',
+  component: Extensions,
+})
+
 export const routeTree = rootRoute.addChildren([
   homeRoute,
   tableRoute,
@@ -114,4 +121,5 @@ export const routeTree = rootRoute.addChildren([
   slowQueriesRoute,
   indexAssistantRoute,
   schemaDiffRoute,
+  extensionsRoute,
 ])

--- a/client-next/src/store/tabs.ts
+++ b/client-next/src/store/tabs.ts
@@ -9,6 +9,7 @@ export type Tab =
   | { kind: 'slow-queries' }
   | { kind: 'index-assistant' }
   | { kind: 'schema-diff' }
+  | { kind: 'extensions' }
   | { kind: 'home' }
 
 function tabId(t: Tab): string {
@@ -21,6 +22,7 @@ function tabId(t: Tab): string {
     case 'slow-queries': return 'slow-queries'
     case 'index-assistant': return 'index-assistant'
     case 'schema-diff': return 'schema-diff'
+    case 'extensions': return 'extensions'
     case 'home': return 'home'
   }
 }
@@ -35,6 +37,7 @@ function tabLabel(t: Tab): string {
     case 'slow-queries': return 'Slow queries'
     case 'index-assistant': return 'Index assistant'
     case 'schema-diff': return 'Schema diff'
+    case 'extensions': return 'Extensions'
     case 'home': return 'Home'
   }
 }
@@ -49,6 +52,7 @@ function tabRoute(t: Tab): string {
     case 'slow-queries': return '/slow-queries'
     case 'index-assistant': return '/index-assistant'
     case 'schema-diff': return '/schema-diff'
+    case 'extensions': return '/extensions'
     case 'home': return '/'
   }
 }

--- a/src/db/extensions.js
+++ b/src/db/extensions.js
@@ -1,0 +1,80 @@
+/**
+ * Postgres extensions panel (roadmap §7.4).
+ *
+ * Lists every extension the server makes available (pg_available_extensions),
+ * with the installed version (null when not installed) and the default version
+ * on offer. Install is a one-click CREATE EXTENSION IF NOT EXISTS, mirroring the
+ * pg_stat_statements enable flow in ./slowQueries — the same privilege error
+ * surfaces with a readable hint when the role can't create extensions.
+ */
+
+const { quoteIdent } = require('./identifier');
+
+// Curated highlights from the roadmap, surfaced first so the common ones aren't
+// buried in the alphabetical long tail. pgvector ships as the `vector` extension.
+const POPULAR = new Set([
+  'pg_trgm', 'vector', 'postgis', 'pg_stat_statements',
+  'pgcrypto', 'uuid-ossp', 'citext', 'hstore',
+]);
+
+async function listExtensions(pool) {
+  const { rows } = await pool.query(
+    `SELECT name, default_version, installed_version, comment
+       FROM pg_available_extensions
+      ORDER BY name`,
+    [],
+  );
+  // current_setting('is_superuser') is 'on'/'off'; lets the UI warn up front
+  // rather than only after a failed install. Trusted extensions (PG13+) can
+  // still be installed by non-superusers, so this is advisory, not a gate.
+  const { rows: priv } = await pool.query(
+    `SELECT current_setting('is_superuser') AS superuser`, []);
+  return {
+    superuser: priv[0]?.superuser === 'on',
+    extensions: rows.map((r) => ({
+      name: r.name,
+      installedVersion: r.installed_version,   // null when not installed
+      defaultVersion: r.default_version,
+      comment: r.comment,
+      installed: r.installed_version != null,
+      popular: POPULAR.has(r.name),
+    })),
+  };
+}
+
+async function installExtension(pool, name) {
+  // Only install names the server actually offers — a clean 400 beats a raw PG
+  // error, and it bounds what quoteIdent ever sees.
+  const { rows } = await pool.query(
+    `SELECT 1 FROM pg_available_extensions WHERE name = $1`, [name]);
+  if (rows.length === 0) {
+    const err = new Error(`Extension "${name}" is not available on this server`);
+    err.code = 'NOT_AVAILABLE';
+    throw err;
+  }
+  await pool.query(`CREATE EXTENSION IF NOT EXISTS ${quoteIdent(name)}`, []);
+  const { rows: after } = await pool.query(
+    `SELECT installed_version FROM pg_available_extensions WHERE name = $1`, [name]);
+  const installedVersion = after[0]?.installed_version ?? null;
+  return { installed: installedVersion != null, installedVersion };
+}
+
+async function dropExtension(pool, name) {
+  const { rows } = await pool.query(
+    `SELECT 1 FROM pg_available_extensions WHERE name = $1`, [name]);
+  if (rows.length === 0) {
+    const err = new Error(`Extension "${name}" is not available on this server`);
+    err.code = 'NOT_AVAILABLE';
+    throw err;
+  }
+  // RESTRICT (the default, left implicit) — never CASCADE. If objects depend on
+  // the extension the drop fails loudly rather than silently deleting them; the
+  // route surfaces that error so the user decides what to remove first.
+  await pool.query(`DROP EXTENSION IF EXISTS ${quoteIdent(name)}`, []);
+  const { rows: after } = await pool.query(
+    `SELECT installed_version FROM pg_available_extensions WHERE name = $1`, [name]);
+  const installedVersion = after[0]?.installed_version ?? null;
+  return { installed: installedVersion != null, installedVersion };
+}
+
+module.exports = { listExtensions, installExtension, dropExtension, POPULAR };

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -28,6 +28,7 @@ const { extractExplainTiming } = require('../db/explain');
 const operations = require('../db/operations');
 const slowQueries = require('../db/slowQueries');
 const indexAdvisor = require('../db/indexAdvisor');
+const extensions = require('../db/extensions');
 const schemaDiff = require('../db/schemaDiff');
 const schemaEdit = require('../db/schemaEdit');
 const { txManager } = require('../db/tx');
@@ -1606,6 +1607,57 @@ router.get('/operations/indexes', requireConnection, async (req, res) => {
     return sendError(res, 500, codes.DB_ERROR, err.message);
   }
 });
+
+// ---- Extensions panel (roadmap §7.4) ---------------------------------------
+//
+// Lists server-available extensions with installed/default versions, and a
+// one-click install that runs CREATE EXTENSION server-side (like the
+// pg_stat_statements enable flow). A privilege failure maps to a readable hint.
+
+router.get('/operations/extensions', requireConnection, async (req, res) => {
+  try {
+    res.json(await extensions.listExtensions(req.pool));
+  } catch (err) {
+    logger.error({ err: err.message }, 'list extensions failed');
+    return sendError(res, 500, codes.DB_ERROR, err.message);
+  }
+});
+
+const ExtensionInstallBody = z.object({ name: z.string().min(1).max(255) });
+
+router.post('/operations/extensions/install',
+  requireConnection,
+  validate({ body: ExtensionInstallBody }),
+  async (req, res) => {
+    try {
+      res.json(await extensions.installExtension(req.pool, req.body.name));
+    } catch (err) {
+      if (err.code === 'NOT_AVAILABLE') {
+        return sendError(res, 400, codes.BAD_REQUEST, err.message);
+      }
+      logger.warn({ err: err.message }, 'install extension failed');
+      return sendError(res, 500, codes.DB_ERROR, err.message, {
+        hint: 'Installing an extension usually requires a superuser (or a trusted extension on PG13+).',
+      });
+    }
+  });
+
+router.post('/operations/extensions/drop',
+  requireConnection,
+  validate({ body: ExtensionInstallBody }),
+  async (req, res) => {
+    try {
+      res.json(await extensions.dropExtension(req.pool, req.body.name));
+    } catch (err) {
+      if (err.code === 'NOT_AVAILABLE') {
+        return sendError(res, 400, codes.BAD_REQUEST, err.message);
+      }
+      logger.warn({ err: err.message }, 'drop extension failed');
+      return sendError(res, 500, codes.DB_ERROR, err.message, {
+        hint: 'Dropping fails if other objects depend on the extension — remove those first, or the role may lack privileges.',
+      });
+    }
+  });
 
 // ---- Schema diff & migration generator (roadmap §7.1) ----------------------
 //

--- a/test/unit/extensions.test.js
+++ b/test/unit/extensions.test.js
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the extensions panel (roadmap §7.4).
+ *
+ * Mirrors slowQueries.test.js: a fake pool returns canned rows by SQL substring
+ * so we can assert the list mapping, the superuser flag, the install-name guard,
+ * and the quoted CREATE EXTENSION without a live Postgres.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { listExtensions, installExtension, dropExtension } = require('../../src/db/extensions');
+
+function fakePool(matchers) {
+  const calls = [];
+  return {
+    calls,
+    query: async (sql, params) => {
+      calls.push({ sql, params });
+      for (const [needle, rows] of matchers) {
+        if (sql.includes(needle)) {
+          if (rows instanceof Error) throw rows;
+          return { rows, fields: [], rowCount: rows.length, command: 'SELECT' };
+        }
+      }
+      return { rows: [], fields: [], rowCount: 0, command: 'SELECT' };
+    },
+  };
+}
+
+test('listExtensions maps rows, derives installed, flags popular + superuser', async () => {
+  const pool = fakePool([
+    ['FROM pg_available_extensions', [
+      { name: 'hstore', default_version: '1.8', installed_version: '1.8', comment: 'key/value' },
+      { name: 'zztop', default_version: '2.0', installed_version: null, comment: null },
+    ]],
+    ['is_superuser', [{ superuser: 'on' }]],
+  ]);
+  const { superuser, extensions } = await listExtensions(pool);
+  assert.equal(superuser, true);
+  assert.deepEqual(extensions[0], {
+    name: 'hstore', installedVersion: '1.8', defaultVersion: '1.8',
+    comment: 'key/value', installed: true, popular: true,
+  });
+  assert.equal(extensions[1].installed, false);
+  assert.equal(extensions[1].popular, false);
+});
+
+test('listExtensions reports superuser:false when is_superuser is off', async () => {
+  const pool = fakePool([
+    ['FROM pg_available_extensions', []],
+    ['is_superuser', [{ superuser: 'off' }]],
+  ]);
+  assert.equal((await listExtensions(pool)).superuser, false);
+});
+
+test('installExtension rejects a name the server does not offer', async () => {
+  // The availability probe returns no row → NOT_AVAILABLE, nothing is created.
+  const pool = fakePool([['FROM pg_available_extensions WHERE name', []]]);
+  await assert.rejects(() => installExtension(pool, 'definitely_not_real'), /not available/);
+  assert.ok(!pool.calls.some((c) => c.sql.includes('CREATE EXTENSION')));
+});
+
+test('installExtension runs a quoted CREATE EXTENSION and returns refreshed status', async () => {
+  const pool = fakePool([
+    ['FROM pg_available_extensions WHERE name', [{ installed_version: '1.6' }]],
+  ]);
+  const result = await installExtension(pool, 'pg_trgm');
+  assert.deepEqual(result, { installed: true, installedVersion: '1.6' });
+  const ddl = pool.calls.find((c) => c.sql.includes('CREATE EXTENSION'));
+  assert.match(ddl.sql, /^CREATE EXTENSION IF NOT EXISTS "pg_trgm"$/);
+});
+
+test('installExtension quotes a name with a double quote (no injection)', async () => {
+  const pool = fakePool([
+    ['FROM pg_available_extensions WHERE name', [{ installed_version: null }]],
+  ]);
+  await installExtension(pool, 'a"b');
+  const ddl = pool.calls.find((c) => c.sql.includes('CREATE EXTENSION'));
+  assert.match(ddl.sql, /CREATE EXTENSION IF NOT EXISTS "a""b"$/);
+});
+
+test('dropExtension runs a quoted DROP ... IF EXISTS (RESTRICT, no CASCADE)', async () => {
+  const pool = fakePool([
+    ['FROM pg_available_extensions WHERE name', [{ installed_version: null }]],
+  ]);
+  const result = await dropExtension(pool, 'hstore');
+  assert.deepEqual(result, { installed: false, installedVersion: null });
+  const ddl = pool.calls.find((c) => c.sql.includes('DROP EXTENSION'));
+  assert.match(ddl.sql, /^DROP EXTENSION IF EXISTS "hstore"$/);
+  assert.doesNotMatch(ddl.sql, /CASCADE/);
+});
+
+test('dropExtension rejects a name the server does not offer', async () => {
+  const pool = fakePool([['FROM pg_available_extensions WHERE name', []]]);
+  await assert.rejects(() => dropExtension(pool, 'definitely_not_real'), /not available/);
+  assert.ok(!pool.calls.some((c) => c.sql.includes('DROP EXTENSION')));
+});


### PR DESCRIPTION
## Summary
Adds the Extensions panel (roadmap §7.4): list server-available Postgres extensions, one-click install, confirmed uninstall.

- **List** — `pg_available_extensions` → name, installed/default version, comment, popular flag + `is_superuser` (advisory).
- **Install** — one-click `CREATE EXTENSION IF NOT EXISTS` server-side (mirrors pg_stat_statements enable). Privilege failure → readable hint.
- **Uninstall** — `DROP EXTENSION IF EXISTS` behind a confirm dialog. RESTRICT, **never CASCADE** — fails loudly if objects depend on it.
- Names validated against server availability; CREATE/DROP use the proper identifier escaper.
- Every action exposes "Show SQL" (Copy) per strategic principle §3.
- Wired into route tree, tab bar, sidebar Operations section.

## Test
- `test/unit/extensions.test.js`: list mapping, superuser flag, name guard, identifier quoting (injection), RESTRICT-not-CASCADE.
- 274 unit tests pass; client typecheck clean.

## Skipped
- CASCADE drop — too easy to nuke dependent tables; user reruns explicit `DROP … CASCADE` in the SQL editor if needed.