### PR TITLE
feat(charts): add chart panel

### DIFF
--- a/client-next/package-lock.json
+++ b/client-next/package-lock.json
@@ -23,6 +23,7 @@
         "monaco-editor": "^0.52.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "recharts": "^3.9.0",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
         "unicode-spinner": "^1.0.0",
@@ -1330,6 +1331,42 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1726,6 +1763,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tanstack/history": {
       "version": "1.162.0",
       "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.162.0.tgz",
@@ -2107,6 +2156,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
@@ -2122,6 +2177,12 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -2131,10 +2192,46 @@
         "@types/d3-color": "*"
       }
     },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
       "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
@@ -2207,6 +2304,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.4",
@@ -3286,6 +3389,18 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -3326,6 +3441,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
@@ -3338,11 +3462,72 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -3428,6 +3613,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -3589,6 +3780,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.48.1.tgz",
+      "integrity": "sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -3838,6 +4039,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -4314,6 +4521,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4349,6 +4566,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-binary-path": {
@@ -5408,8 +5634,30 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5442,6 +5690,36 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.0.tgz",
+      "integrity": "sha512-dCEcE9y20c8H2tkVeByrAXhhnBJk6/QLbxKmn+dJUptOfc5NMjwRh1jo0vZPRLD+5dMrHrP+hPEsfbGBMfnf5Q==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -5455,6 +5733,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -6019,6 +6318,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6307,6 +6612,28 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/client-next/package.json
+++ b/client-next/package.json
@@ -29,6 +29,7 @@
     "monaco-editor": "^0.52.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "recharts": "^3.9.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "unicode-spinner": "^1.0.0",

--- a/client-next/src/components/ChartPanel.tsx
+++ b/client-next/src/components/ChartPanel.tsx
@@ -1,0 +1,218 @@
+import { useMemo, useState } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import { Select } from '@/components/ui/select'
+import {
+  classifyColumns,
+  suggestCharts,
+  type ChartType,
+} from '@/lib/chartSuggest'
+
+/**
+ * Chart panel (roadmap §7.5). Renders the rows in hand as a line / bar / scatter
+ * chart, auto-suggesting a type and axes from the column types. The user can
+ * override the type and either axis. Plots client-side from the result already
+ * loaded — no re-query — so it works for both raw query results and no-code
+ * table pages.
+ *
+ * Saving a chart as part of a view (also §7.5) is not wired yet — views persist
+ * column widths / filters / sort, not chart config.
+ */
+
+// ponytail: cap plotted points; SVG charts choke past a few thousand and the
+// shape is unreadable anyway. Raise / add downsampling if real use needs more.
+const MAX_POINTS = 500
+
+const ACCENT = 'hsl(221 83% 53%)' // blue-600, readable on light + dark
+
+type Row = Record<string, unknown>
+
+export function ChartPanel({
+  rows,
+  columns,
+}: {
+  rows: Row[]
+  columns: { name: string; type: string }[]
+}) {
+  const cols = useMemo(() => classifyColumns(columns, rows), [columns, rows])
+  const suggestions = useMemo(() => suggestCharts(cols), [cols])
+  const first = suggestions[0]
+
+  const [type, setType] = useState<ChartType>(first?.type ?? 'bar')
+  const [x, setX] = useState(first?.x ?? columns[0]?.name ?? '')
+  const [y, setY] = useState(first?.y ?? columns[0]?.name ?? '')
+
+  // Build the plot data: numeric y (drop unparseable), numeric x for scatter.
+  const data = useMemo(() => {
+    const out: { x: unknown; y: number }[] = []
+    for (const r of rows) {
+      const yv = Number(r[y])
+      if (!Number.isFinite(yv)) continue
+      const xv = type === 'scatter' ? Number(r[x]) : r[x]
+      if (type === 'scatter' && !Number.isFinite(xv as number)) continue
+      out.push({ x: xv, y: yv })
+      if (out.length >= MAX_POINTS) break
+    }
+    return out
+  }, [rows, x, y, type])
+
+  if (columns.length === 0 || rows.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">No rows to chart.</p>
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3">
+      <div className="flex shrink-0 flex-wrap items-end gap-3">
+        <Field label="Chart">
+          <Select
+            value={type}
+            onChange={(e) => setType(e.target.value as ChartType)}
+          >
+            <option value="line">Line</option>
+            <option value="bar">Bar</option>
+            <option value="scatter">Scatter</option>
+          </Select>
+        </Field>
+        <Field label="X axis">
+          <ColSelect value={x} columns={columns} onChange={setX} />
+        </Field>
+        <Field label="Y axis">
+          <ColSelect value={y} columns={columns} onChange={setY} />
+        </Field>
+        {suggestions.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {suggestions.map((s) => (
+              <button
+                key={s.label}
+                onClick={() => {
+                  setType(s.type)
+                  setX(s.x)
+                  setY(s.y)
+                }}
+                className="rounded border border-border bg-muted/40 px-2 py-1 text-xs text-muted-foreground transition hover:text-foreground"
+                title="Apply suggested chart"
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1">
+        {data.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Pick a numeric Y column to chart.
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            {renderChart(type, data)}
+          </ResponsiveContainer>
+        )}
+      </div>
+      {data.length >= MAX_POINTS && (
+        <p className="shrink-0 text-xs text-muted-foreground">
+          Showing first {MAX_POINTS} points.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function renderChart(type: ChartType, data: { x: unknown; y: number }[]) {
+  const grid = (
+    <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+  )
+  const axes = (
+    <>
+      <XAxis
+        dataKey="x"
+        tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+        type={type === 'scatter' ? 'number' : 'category'}
+      />
+      <YAxis tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }} />
+      <Tooltip
+        contentStyle={{
+          background: 'hsl(var(--card))',
+          border: '1px solid hsl(var(--border))',
+          borderRadius: 6,
+          fontSize: 12,
+        }}
+      />
+    </>
+  )
+  if (type === 'line') {
+    return (
+      <LineChart data={data}>
+        {grid}
+        {axes}
+        <Line type="monotone" dataKey="y" stroke={ACCENT} dot={false} />
+      </LineChart>
+    )
+  }
+  if (type === 'scatter') {
+    return (
+      <ScatterChart>
+        {grid}
+        {axes}
+        <Scatter data={data} fill={ACCENT} />
+      </ScatterChart>
+    )
+  }
+  return (
+    <BarChart data={data}>
+      {grid}
+      {axes}
+      <Bar dataKey="y" fill={ACCENT} />
+    </BarChart>
+  )
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+      {label}
+      <div className="w-40">{children}</div>
+    </label>
+  )
+}
+
+function ColSelect({
+  value,
+  columns,
+  onChange,
+}: {
+  value: string
+  columns: { name: string; type: string }[]
+  onChange: (v: string) => void
+}) {
+  return (
+    <Select value={value} onChange={(e) => onChange(e.target.value)}>
+      {columns.map((c) => (
+        <option key={c.name} value={c.name}>
+          {c.name}
+        </option>
+      ))}
+    </Select>
+  )
+}

--- a/client-next/src/components/QueryResults.tsx
+++ b/client-next/src/components/QueryResults.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from 'react'
-import { CheckCircle2, Download } from 'lucide-react'
+import { BarChart3, CheckCircle2, Download } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
+import { Dialog } from '@/components/ui/dialog'
+import { ChartPanel } from '@/components/ChartPanel'
 import { DataGrid, type SortState } from '@/components/DataGrid'
 import { ExplainPlan } from '@/components/ExplainPlan'
 import {
@@ -77,6 +79,7 @@ function ResultTabs({
   baseName: string
 }) {
   const [active, setActive] = useState(0)
+  const [chartOpen, setChartOpen] = useState(false)
   // Per-tab client-side sort (the result is already in memory — no re-query).
   const [sortByTab, setSortByTab] = useState<Record<number, SortState>>({})
 
@@ -132,6 +135,14 @@ function ResultTabs({
         </span>
         {current.rows.length > 0 && (
           <div className="flex shrink-0 items-center gap-1">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setChartOpen(true)}
+              title="Chart this result"
+            >
+              <BarChart3 className="h-3.5 w-3.5" /> Chart
+            </Button>
             <ExportButton
               format="csv"
               onClick={() =>
@@ -168,6 +179,23 @@ function ResultTabs({
           </p>
         )}
       </div>
+
+      <Dialog
+        open={chartOpen}
+        onClose={() => setChartOpen(false)}
+        title="Chart"
+        className="max-w-4xl"
+      >
+        <div className="h-[70vh]">
+          <ChartPanel
+            rows={sortedRows}
+            columns={Object.entries(columns).map(([name, m]) => ({
+              name,
+              type: m.dataType,
+            }))}
+          />
+        </div>
+      </Dialog>
     </div>
   )
 }

--- a/client-next/src/lib/chartSuggest.ts
+++ b/client-next/src/lib/chartSuggest.ts
@@ -1,0 +1,122 @@
+/**
+ * Column classification + chart-type suggestion for the §7.5 chart panel.
+ *
+ * Given the columns of a result (each a Postgres type name from pgTypes, plus a
+ * few sample values for when the type is unknown) it buckets every column into
+ * numeric / temporal / categorical and proposes 2–3 chart types with sensible
+ * default axes:
+ *   - line    — temporal x + numeric y (time series)
+ *   - bar     — categorical x + numeric y
+ *   - scatter — numeric x + numeric y
+ */
+
+export type ColKind = 'numeric' | 'temporal' | 'categorical'
+export type ChartType = 'line' | 'bar' | 'scatter'
+
+export interface ChartColumn {
+  name: string
+  kind: ColKind
+}
+
+export interface ChartSuggestion {
+  type: ChartType
+  x: string
+  y: string
+  /** Human label, e.g. "Line · created_at × count". */
+  label: string
+}
+
+type Row = Record<string, unknown>
+
+const NUMERIC_TYPES = new Set([
+  'int2',
+  'int4',
+  'int8',
+  'float4',
+  'float8',
+  'numeric',
+  'oid',
+])
+const TEMPORAL_TYPES = new Set([
+  'date',
+  'time',
+  'timetz',
+  'timestamp',
+  'timestamptz',
+])
+
+/** First non-null value in a column, for type sniffing when the OID is unknown. */
+function sampleValue(rows: Row[], name: string): unknown {
+  for (const r of rows) {
+    const v = r[name]
+    if (v != null) return v
+  }
+  return null
+}
+
+/** Classify one column from its Postgres type name, falling back to its data. */
+export function classifyColumn(
+  type: string,
+  rows: Row[],
+  name: string,
+): ColKind {
+  if (NUMERIC_TYPES.has(type)) return 'numeric'
+  if (TEMPORAL_TYPES.has(type)) return 'temporal'
+  // A known non-number/date type (text, bool, uuid, …). `oid:NNNN` is pgTypes'
+  // placeholder for an unrecognised OID, so it falls through to value sniffing.
+  if (type && !type.startsWith('oid:')) return 'categorical'
+
+  // Unknown type (oid:NNNN or empty) — sniff the first value.
+  const v = sampleValue(rows, name)
+  if (typeof v === 'number') return 'numeric'
+  if (v instanceof Date) return 'temporal'
+  if (typeof v === 'string' && !Number.isNaN(Date.parse(v))) return 'temporal'
+  return 'categorical'
+}
+
+export function classifyColumns(
+  columns: { name: string; type: string }[],
+  rows: Row[],
+): ChartColumn[] {
+  return columns.map((c) => ({
+    name: c.name,
+    kind: classifyColumn(c.type, rows, c.name),
+  }))
+}
+
+const TYPE_LABEL: Record<ChartType, string> = {
+  line: 'Line',
+  bar: 'Bar',
+  scatter: 'Scatter',
+}
+
+function suggestion(type: ChartType, x: string, y: string): ChartSuggestion {
+  return { type, x, y, label: `${TYPE_LABEL[type]} · ${x} × ${y}` }
+}
+
+/**
+ * Propose chart types for a set of classified columns. Returns at most three,
+ * ordered most-relevant first; empty when no numeric column exists to plot.
+ */
+export function suggestCharts(cols: ChartColumn[]): ChartSuggestion[] {
+  const numeric = cols.filter((c) => c.kind === 'numeric')
+  const temporal = cols.filter((c) => c.kind === 'temporal')
+  const categorical = cols.filter((c) => c.kind === 'categorical')
+
+  const out: ChartSuggestion[] = []
+  if (temporal[0] && numeric[0]) {
+    out.push(suggestion('line', temporal[0].name, numeric[0].name))
+  }
+  if (categorical[0] && numeric[0]) {
+    out.push(suggestion('bar', categorical[0].name, numeric[0].name))
+  }
+  if (numeric[1]) {
+    out.push(suggestion('scatter', numeric[0].name, numeric[1].name))
+  }
+  // Fallback: a single numeric column still charts as a bar over row index.
+  if (out.length === 0 && numeric[0]) {
+    const x = cols.find((c) => c.kind !== 'numeric')?.name ?? numeric[0].name
+    out.push(suggestion('bar', x, numeric[0].name))
+  }
+  return out
+}

--- a/client-next/src/pages/TableView.tsx
+++ b/client-next/src/pages/TableView.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight, Gauge, Plus, Upload } from "lucide-react";
+import { BarChart3, ChevronLeft, ChevronRight, Gauge, Plus, Upload } from "lucide-react";
 
 import { Loading, Spinner } from "@/components/ui/spinner";
 
 import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { ChartPanel } from "@/components/ChartPanel";
 import { Select } from "@/components/ui/select";
 import { DataGrid, type SortState } from "@/components/DataGrid";
 import { EMPTY_FILTER, FilterBar } from "@/components/FilterBar";
@@ -101,6 +103,7 @@ export function TableView() {
   const [insertOpen, setInsertOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [explainOpen, setExplainOpen] = useState(false);
+  const [chartOpen, setChartOpen] = useState(false);
   // The FK cell the user clicked → drives the referenced-row side panel.
   const [fkTarget, setFkTarget] = useState<FkTarget | null>(null);
 
@@ -354,6 +357,14 @@ export function TableView() {
                     title="Visualize the query plan for the current filter & sort (roadmap §6.3)"
                   >
                     <Gauge className="h-4 w-4" /> Explain plan
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setChartOpen(true)}
+                    title="Chart this page of rows (roadmap §7.5)"
+                  >
+                    <BarChart3 className="h-4 w-4" /> Chart
                   </Button>
                 </>
               )}
@@ -611,6 +622,25 @@ export function TableView() {
         sql={generatedSql}
         title={`Query plan · ${tableName}`}
       />
+
+      <Dialog
+        open={chartOpen}
+        onClose={() => setChartOpen(false)}
+        title={`Chart · ${tableName}`}
+        className="max-w-4xl"
+      >
+        <div className="h-[70vh]">
+          {data?.columns && (
+            <ChartPanel
+              rows={data.rows}
+              columns={Object.entries(data.columns).map(([name, m]) => ({
+                name,
+                type: m.dataType,
+              }))}
+            />
+          )}
+        </div>
+      </Dialog>
 
       {fkTarget && (
         <FkPanel

--- a/client-next/test/unit/chartSuggest.test.ts
+++ b/client-next/test/unit/chartSuggest.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  classifyColumn,
+  classifyColumns,
+  suggestCharts,
+} from '@/lib/chartSuggest'
+
+describe('classifyColumn', () => {
+  it('classifies by Postgres type name', () => {
+    expect(classifyColumn('int4', [], 'n')).toBe('numeric')
+    expect(classifyColumn('numeric', [], 'n')).toBe('numeric')
+    expect(classifyColumn('timestamptz', [], 'd')).toBe('temporal')
+    expect(classifyColumn('date', [], 'd')).toBe('temporal')
+    expect(classifyColumn('text', [], 's')).toBe('categorical')
+    expect(classifyColumn('bool', [], 's')).toBe('categorical')
+  })
+
+  it('sniffs values when the type is unknown', () => {
+    const rows = [{ a: null }, { a: 42 }]
+    expect(classifyColumn('', rows, 'a')).toBe('numeric')
+    expect(classifyColumn('oid:99999', [{ a: '2024-01-01' }], 'a')).toBe(
+      'temporal',
+    )
+    expect(classifyColumn('', [{ a: 'hello' }], 'a')).toBe('categorical')
+  })
+})
+
+describe('suggestCharts', () => {
+  it('suggests a line for temporal + numeric (time series)', () => {
+    const cols = classifyColumns(
+      [
+        { name: 'day', type: 'date' },
+        { name: 'count', type: 'int8' },
+      ],
+      [],
+    )
+    const [first] = suggestCharts(cols)
+    expect(first).toMatchObject({ type: 'line', x: 'day', y: 'count' })
+  })
+
+  it('suggests a bar for categorical + numeric', () => {
+    const cols = classifyColumns(
+      [
+        { name: 'status', type: 'text' },
+        { name: 'total', type: 'numeric' },
+      ],
+      [],
+    )
+    expect(suggestCharts(cols).map((s) => s.type)).toContain('bar')
+  })
+
+  it('suggests a scatter for two numerics', () => {
+    const cols = classifyColumns(
+      [
+        { name: 'x', type: 'float8' },
+        { name: 'y', type: 'float8' },
+      ],
+      [],
+    )
+    expect(suggestCharts(cols).map((s) => s.type)).toContain('scatter')
+  })
+
+  it('returns nothing to plot with no numeric column', () => {
+    const cols = classifyColumns(
+      [
+        { name: 'a', type: 'text' },
+        { name: 'b', type: 'uuid' },
+      ],
+      [],
+    )
+    expect(suggestCharts(cols)).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## What

Chart panel. Click **Chart** on any query result or no-code table page to plot the rows in hand as a **line / bar / scatter** chart.

- Column types classified (numeric / temporal / categorical) to auto-suggest 2–3 chart types with sensible default axes
- Chart type and either axis are overridable; suggestion chips one-click apply
- Renders client-side from the loaded result via **recharts** — no re-query
- Works from both the SQL query results (`QueryResults`) and the no-code table view (`TableView`, current page)
- Caps at 500 plotted points (SVG charts get unreadable past that)

## Files

- `lib/chartSuggest.ts` — classification + suggestion logic (sniffs values when the type OID is unknown)
- `components/ChartPanel.tsx` — controls + recharts render
- `components/QueryResults.tsx`, `pages/TableView.tsx` — Chart button → dialog
- `test/unit/chartSuggest.test.ts` — 6 unit tests

## Deferred

Saving a chart as part of a view — views persist column widths / filter / sort, no chart-config slot yet.

## Checks

`tsc --noEmit` clean · 123 unit tests pass